### PR TITLE
Adds the ability to automatically assign user groups on product purchase, also adds order event hooks

### DIFF
--- a/vivid_store/controller.php
+++ b/vivid_store/controller.php
@@ -29,7 +29,7 @@ class Controller extends Package
 
     protected $pkgHandle = 'vivid_store';
     protected $appVersionRequired = '5.7.3';
-    protected $pkgVersion = '2.0.1';
+    protected $pkgVersion = '2.0.2';
     
     
     

--- a/vivid_store/controllers/single_page/dashboard/store/products.php
+++ b/vivid_store/controllers/single_page/dashboard/store/products.php
@@ -11,6 +11,7 @@ use Database;
 use File;
 use Loader;
 use PageType;
+use GroupList;
 
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductList as VividProductList;
@@ -25,6 +26,9 @@ class Products extends DashboardPageController
 {
 
     public function view($gID=null){
+        $v = View::getInstance();
+        $v->requireAsset('select2');
+
         $products = new VividProductList();
         $products->setItemsPerPage(10);
         $products->setGroupID($gID);
@@ -40,7 +44,6 @@ class Products extends DashboardPageController
         $this->addFooterItem(Core::make('helper/html')->javascript($packagePath.'/js/vividStoreFunctions.js'));
         $grouplist = VividProductGroupList::getGroupList();            
         $this->set("grouplist",$grouplist);
-        
     }
     public function success(){
         $this->set("success",t("Product Added"));
@@ -67,7 +70,22 @@ class Products extends DashboardPageController
         foreach($grouplist as $productgroup){
             $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
         }     
-        $this->set("productgroups",$productgroups);          
+        $this->set("productgroups",$productgroups);
+
+        $usergrouparray = array();
+
+        $gl = new GroupList();
+        $gl->setItemsPerPage(1000);
+        $gl->filterByAssignable();
+        $usergroups = $gl->get();
+
+        foreach($usergroups as $ug) {
+            if ( $ug->gName != 'Administrators') {
+                $usergrouparray[$ug->gID] = $ug->gName;
+            }
+        }
+
+        $this->set('usergroups', $usergrouparray);
     }
     public function edit($pID)
     {
@@ -87,8 +105,22 @@ class Products extends DashboardPageController
         foreach($grouplist as $productgroup){
             $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
         }     
-        $this->set("productgroups",$productgroups);
-        
+        $this->set("productgroups",$product);
+
+        $usergrouparray = array();
+
+        $gl = new GroupList();
+        $gl->setItemsPerPage(1000);
+        $gl->filterByAssignable();
+        $usergroups = $gl->get();
+
+        foreach($usergroups as $ug) {
+            if ( $ug->gName != 'Administrators') {
+                $usergrouparray[$ug->gID] = $ug->gName;
+            }
+        }
+
+        $this->set('usergroups', $usergrouparray);
     }
     public function generate($pID,$templateID=null)
     {
@@ -142,8 +174,7 @@ class Products extends DashboardPageController
             $this->error = null; //clear errors
             $this->error = $errors;
             if (!$errors->has()) {
-                
-                $product = VividProduct::save($data); 
+                $product = VividProduct::save($data);
         		$aks = StoreProductKey::getList();
         		foreach($aks as $uak) {
         			$uak->saveAttributeForm($product);				

--- a/vivid_store/db.xml
+++ b/vivid_store/db.xml
@@ -21,6 +21,8 @@
 		<field name="pHeight" type="I"></field>
 		<field name="pLength" type="I"></field>
 		<field name="pWeight" type="I"></field>
+        <field name="pUserGroups" type="C" size="255">
+        </field>
 	</table>
 	<table name="VividStoreProductOptionGroup">
         <field name="pogID" type="I"><key /><unsigned /><autoincrement/></field>

--- a/vivid_store/single_pages/dashboard/store/products.php
+++ b/vivid_store/single_pages/dashboard/store/products.php
@@ -36,7 +36,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     
                         <ul>
                             <li><a href="#product-overview" data-pane-toggle class="active"><?=t('Overview')?></a></li>
-                            <li><a href="#product-digital" data-pane-toggle><?=t("Digital Products")?></a></li>
+                            <li><a href="#product-digital" data-pane-toggle><?=t("Digital Products and User Groups")?></a></li>
                             <li><a href="#product-images" data-pane-toggle><?=t('Images')?></a></li>
                             <li><a href="#product-details" data-pane-toggle><?=t('Details')?></a></li>
                             <li><a href="#product-options" data-pane-toggle><?=t('Options')?></a></li>
@@ -103,6 +103,26 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <?php echo $form->label("dffID".$i, t("File to download on purchase"));?>
                             <?php echo $al->file('dffID'.$i, 'dffID[]', t('Choose File'), is_object($file)?$file:null)?>
                         </div>
+
+                        <div class="form-group">
+                            <?php echo $form->label("usergroups", t("On purchase add user to user groups"));?>
+                            <div class="ccm-search-field-content ccm-search-field-content-select2">
+                                <select multiple="multiple" name="pUserGroups[]" id="groupselect" class="select2-select" style="width: 100%;">
+                                    <?php
+                                    $selectedusergroups = $p->getProductUserGroups();
+                                    foreach ($usergroups as $ugkey=>$uglabel) { ?>
+                                        <option value="<?php echo $ugkey;?>" <?php echo (in_array($ugkey, $selectedusergroups) ? 'selected="selected"' : ''); ?>>  <?php echo $uglabel; ?></option>
+                                    <?php } ?>
+                                </select>
+                            </div>
+                        </div>
+
+                    <script type="text/javascript">
+                        $(function() {
+                            $('#groupselect').select2();
+                        });
+                    </script>
+
                     <?php } 
                     } else { ?>
                         <div class="alert alert-info">
@@ -424,8 +444,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             indexOptionItems();                            
                         }
                         $(function(){
-                            
-                            
                             //Make items sortable. If we re-sort them, re-index them.
                             $(".option-group-item-container").sortable({
                                 handle: ".grabme",

--- a/vivid_store/src/VividStore/Orders/Item.php
+++ b/vivid_store/src/VividStore/Orders/Item.php
@@ -5,6 +5,7 @@ use Database;
 use File;
 use User;
 use UserInfo;
+use Group;
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 defined('C5_EXECUTE') or die(_("Access Denied."));
@@ -39,24 +40,36 @@ class Item extends Object
             $optionGroupID = str_replace("pog","",$optionGroup);
             $optionGroupName = VividProduct::getProductOptionGroupNameByID($optionGroupID);
             $optionValue = VividProduct::getProductOptionValueByID($selectedOption);
-            
-            
+
             $values = array($oiID,$optionGroupName,$optionValue);
             $db->Execute("INSERT INTO VividStoreOrderItemOption(oiID,oioKey,oioValue) values(?,?,?)",$values);
         }
+
+        $u = new User();
+        $uID = $u->getUserID();
+        $ui = UserInfo::getByID($uID);
+
         if($product->hasDigitalDownload()){
             $fileObjs = $product->getProductDownloadFileObjects(); 
             $fileObj = $fileObjs[0];    
             $pk = \Concrete\Core\Permission\Key\FileKey::getByHandle('view_file');
             $pk->setPermissionObject($fileObj);
             $pao = $pk->getPermissionAssignmentObject();
-            $u = new User();
-            $uID = $u->getUserID();
-            $ui = UserInfo::getByID($uID);
             $user = \Concrete\Core\Permission\Access\Entity\UserEntity::getOrCreate($ui);                    
             $pa = $pk->getPermissionAccessObject();
             $pa->addListItem($user);
             $pao->assignPermissionAccess($pa);
+        }
+        if($product->hasUserGroups()){
+            $usergroupstoadd = $product->getProductUserGroups();
+
+            foreach($usergroupstoadd as $id) {
+                $g = Group::getByID($id);
+
+                if ($g) {
+                    $u->enterGroup($g);
+                }
+            }
         }
         
     }    

--- a/vivid_store/src/VividStore/Orders/OrderEvent.php
+++ b/vivid_store/src/VividStore/Orders/OrderEvent.php
@@ -1,0 +1,21 @@
+<?php
+namespace Concrete\Package\VividStore\src\VividStore\Orders;
+use \Symfony\Component\EventDispatcher\GenericEvent;
+
+class OrderEvent extends GenericEvent {
+
+    protected $event;
+
+    public function __construct($currentOrder, $previousOrder = null) {
+        $this->currentOrder = $currentOrder;
+        $this->previousOrder = $previousOrder;
+    }
+
+    public function getCurrentOrder() {
+        return $this->currentOrder;
+    }
+
+    public function getOrderBeforeChange() {
+       return $this->previousOrder;
+    }
+}

--- a/vivid_store/src/VividStore/Product/Product.php
+++ b/vivid_store/src/VividStore/Product/Product.php
@@ -43,14 +43,16 @@ class Product extends Object
     public function save($data)
     {
         $db = Database::get();
+        $data['pUserGroups'] = implode(',', $data['pUserGroups']);
+
         if($data['pID']){
         //if we know the pID, we're updating.
                 
-            $pID = $data['pID']; 
-                
+            $pID = $data['pID'];
+
             //update product details
-            $vals = array($data['gID'],$data['pName'],$data['pDesc'],$data['pDetail'],$data['pPrice'],$data['pFeatured'],$data['pQty'],$data['pTaxable'],$data['pfID'],$data['pActive'],$data['pShippable'],$data['pWidth'],$data['pHeight'],$data['pLength'],$data['pWeight'],$data['pID']);
-            $db->Execute('UPDATE VividStoreProduct SET gID=?,pName=?,pDesc=?,pDetail=?,pPrice=?,pFeatured=?,pQty=?,pTaxable=?,pfID=?,pActive=?,pShippable=?,pWidth=?,pHeight=?,pLength=?,pWeight=? WHERE pID = ?', $vals);
+            $vals = array($data['gID'],$data['pName'],$data['pDesc'],$data['pDetail'],$data['pPrice'],$data['pFeatured'],$data['pQty'],$data['pTaxable'],$data['pfID'],$data['pUserGroups'],$data['pActive'],$data['pShippable'],$data['pWidth'],$data['pHeight'],$data['pLength'],$data['pWeight'],$data['pID']);
+            $db->Execute('UPDATE VividStoreProduct SET gID=?,pName=?,pDesc=?,pDetail=?,pPrice=?,pFeatured=?,pQty=?,pTaxable=?,pfID=?,pUserGroups=?,pActive=?,pShippable=?,pWidth=?,pHeight=?,pLength=?,pWeight=? WHERE pID = ?', $vals);
             
             //update additional images
             $db->Execute('DELETE from VividStoreProductImage WHERE pID = ?', $data['pID']);
@@ -90,8 +92,8 @@ class Product extends Object
             $now = $dt->getLocalDateTime();
             
             //add product details
-            $vals = array($data['gID'],$data['pName'],$data['pDesc'],$data['pDetail'],$data['pPrice'],$data['pFeatured'],$data['pQty'],$data['pTaxable'],$data['pfID'],$data['pActive'],$data['pShippable'],$data['pWidth'],$data['pHeight'],$data['pLength'],$data['pWeight'],$now);
-            $db->Execute("INSERT into VividStoreProduct (gID,pName,pDesc,pDetail,pPrice,pFeatured,pQty,pTaxable,pfID,pActive,pShippable,pWidth,pHeight,pLength,pWeight,pDateAdded) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",$vals);
+            $vals = array($data['gID'],$data['pName'],$data['pDesc'],$data['pDetail'],$data['pPrice'],$data['pFeatured'],$data['pQty'],$data['pTaxable'],$data['pfID'],$data['pUserGroups'],$data['pActive'],$data['pShippable'],$data['pWidth'],$data['pHeight'],$data['pLength'],$data['pWeight'],$now);
+            $db->Execute("INSERT into VividStoreProduct (gID,pName,pDesc,pDetail,pPrice,pFeatured,pQty,pTaxable,pfID,pUserGroups,pActive,pShippable,pWidth,pHeight,pLength,pWeight,pDateAdded) values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",$vals);
             
             //add additional images
             $pID = $db->lastInsertId();
@@ -254,6 +256,12 @@ class Product extends Object
             $fileObjects[] = File::getByID($result['dffID']);
         }  
         return $fileObjects;
+    }
+    public function hasUserGroups(){
+        return (bool)trim($this->pUserGroups);
+    }
+    public function getProductUserGroups(){
+        return explode(',', $this->pUserGroups);
     }
     public function getProductImage(){
         $fileObj = $this->getProductImageObj();


### PR DESCRIPTION
I’ve just put the user group selector in the same spot as the fileselector - it might be better off in its own tab.

I've used a single field to store the user groups, instead of a separate table here. As we are only store a list of group ids, with the order being irrelevant, and there being no other needed data I think this is an appropriate case to serialise data like this instead of having another database table - but I won't be offended if this isn't agreeable.

With the event hooks, I haven’t _actually_ tested using them yet, but there’s very little to go wrong.
