### PR TITLE
Update Order Statuses

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -14,12 +14,14 @@ use Group;
 use View;
 use Database;
 use FileSet;
+use Loader;
 use Concrete\Core\Database\Schema\Schema;
 use \Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
 use \Concrete\Core\Attribute\Key\UserKey as UserAttributeKey;
 use \Concrete\Core\Attribute\Type as AttributeType;
 use \Concrete\Package\VividStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKey;
 use \Concrete\Package\VividStore\Src\VividStore\Payment\Method as PaymentMethod;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
 use \Concrete\Core\Utility\Service\Text;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
@@ -347,6 +349,8 @@ class Controller extends Package
         if(!is_object($fs)){
             FileSet::add("Digital Downloads");
         }
+
+        $this->addOrderStatusesToDatabase($pkg);
     }
 
     public function upgrade()
@@ -496,6 +500,27 @@ class Controller extends Package
         $attrPage = Page::getByPath('/dashboard/store/products/attributes');
         if(!is_object($attrPage) || $attrPage->isError()){
             SinglePage::add('/dashboard/store/products/attributes',$pkg);
+        }
+        $this->addOrderStatusesToDatabase($pkg);
+    }
+
+    private function addOrderStatusesToDatabase($pkg) {
+        $table = OrderStatus::getTableName();
+        $db = Loader::db();
+        $statuses = array(
+            array('osHandle'=>'pending', 'osName'=>'Pending', 'osInformSite'=>1, 'osInformCustomer'=>1),
+            array('osHandle'=>'processing', 'osName'=>'processing', 'osInformSite'=>1, 'osInformCustomer'=>1),
+            array('osHandle'=>'shipped', 'osName'=>'shipped', 'osInformSite'=>1, 'osInformCustomer'=>1),
+            array('osHandle'=>'complete', 'osName'=>'Complete', 'osInformSite'=>1, 'osInformCustomer'=>1),
+        );
+        foreach ($statuses as $status) {
+            $row = $db->GetRow("SELECT * FROM ".$table." WHERE osHandle=?", array($status['osHandle']));
+            if (!isset($row['osHandle'])) {
+                OrderStatus::add($status['osHandle'], $status['osName'], $status['osInformSite'], $status['osInformCustomer']);
+            } else {
+                $orderStatus = OrderStatus::getByID($row['osID']);
+                $orderStatus->update($status, true);
+            }
         }
     }
     

--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -4,6 +4,7 @@ namespace Concrete\Package\VividStore\Controller\SinglePage\Dashboard\Store;
 use \Concrete\Core\Page\Controller\DashboardPageController;
 use Core;
 use Package;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
 
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderList;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\Order as VividOrder;
@@ -21,11 +22,13 @@ class Orders extends DashboardPageController
         $this->set('orderList',$paginator->getCurrentPageResults());  
         $this->set('pagination',$pagination);
         $this->set('paginator', $paginator);     
+        $this->set('orderStatuses', OrderStatus::getList());
     }
     public function order($oID)
     {
         $order = VividOrder::getByID($oID);
         $this->set("order",$order);
+        $this->set('orderStatuses', OrderStatus::getList());
         $pkg = Package::getByHandle('vivid_store');
         $packagePath = $pkg->getRelativePath();
         $this->addFooterItem(Core::make('helper/html')->javascript($packagePath.'/js/vividStoreFunctions.js'));

--- a/css/vividStoreDashboard.css
+++ b/css/vividStoreDashboard.css
@@ -29,6 +29,7 @@
             
 .store-pane { display: none; }
 .store-pane.active { display: block; }
+    .sortable { cursor: move; text-align: center; }
 
 
 /* Dynamic Image Selector */

--- a/db.xml
+++ b/db.xml
@@ -66,6 +66,22 @@
         <field name="oTax" type="C" size="10"></field>
         <field name="oTotal" type="C" size="10"></field>
     </table>
+    <table name="VividStoreOrderStatus">
+        <field name="osID" type="I"><key /><unsigned /><autoincrement/></field>
+        <field name="osHandle" type="C" size="255"></field>
+        <field name="osName" type="C" size="255"></field>
+        <field name="osInformSite" type="I"></field>
+        <field name="osInformCustomer" type="I"></field>
+        <field name="osIsStartingStatus" type="I"></field>
+        <field name="osSortOrder" type="I"></field>
+    </table>
+    <table name="VividStoreOrderStatusHistory">
+        <field name="oshID" type="I"><key /><unsigned /><autoincrement/></field>
+        <field name="oID" type="I"></field>
+        <field name="oshStatus" type="C" size="50"></field>
+        <field name="oshDate" type="T"><deftimestamp/></field>
+        <field name="uID" type="I"></field>
+    </table>
     <table name="VividStoreOrderItem">
         <field name="oiID" type="I"><key /><unsigned /><autoincrement/></field>
         <field name="pID" type="I"></field>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -84,27 +84,60 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <strong class="text-large"><?=t("Total")?>:</strong>  <?=$order->getTotal()?><br>
         <strong><?=t("Payment Method")?>:</strong> <?=$order->getPaymentMethodName()?>
     </p>
-    
-    <h3><?=t("Manage Order")?></h3>
+
+    <h3><?=t("Order Status History")?></h3>
     <hr>
     <div class="row">
-        <div class="col-sm-4">
+        <div class="col-sm-4 col-sm-push-8 col-md-3 col-md-push-9">
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <h4 class="panel-title"><?=t("Manage Status")?></h4>
+                    <h4 class="panel-title"><?=t("Update Status")?></h4>
                 </div>
                 <div class="panel-body">
-                    
+
                     <form action="<?=View::url("/dashboard/store/orders/updatestatus",$order->getOrderID())?>" method="post">
                         <div class="form-group">
-                            <?php echo $form->select("orderStatus",array("pending"=>"Pending","processing"=>"Processing","shipped"=>t("Shipped"),"complete"=>"Complete"),$order->getStatus());?>
+                            <?php echo $form->select("orderStatus",$orderStatuses,$order->getStatus());?>
                         </div>
                         <input type="submit" class="btn btn-default" value="<?=t("Update")?>">
                     </form>
-                    
+
                 </div>
             </div>
         </div>
+        <div class="col-sm-8 col-sm-pull-4 col-md-9 col-md-pull-3">
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th><strong><?=t("Status")?></strong></th>
+                    <th><?=t("Date")?></th>
+                    <th><?=t("User")?></th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php
+                $history = $order->getStatusHistory();
+                if($history){
+                    foreach($history as $status){
+                        ?>
+                        <tr>
+                            <td><?=$status->getOrderStatusName()?></td>
+                            <td><?=$status->getDate()?></td>
+                            <td><?=$status->getUserName()?></td>
+                        </tr>
+                    <?php
+                    }
+                }
+                ?>
+                </tbody>
+            </table>
+        </div>
+
+    </div>
+
+    <h3><?=t("Manage Order")?></h3>
+    <hr>
+    <div class="row">
         <div class="col-sm-4">
             <div class="panel panel-default">
                 <div class="panel-heading">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -12,6 +12,7 @@
                             <li><a href="#settings-tax" data-pane-toggle><?=t('Tax')?></a></li>
                             <li><a href="#settings-shipping" data-pane-toggle><?=t('Shipping')?></a></li>
                             <li><a href="#settings-payments" data-pane-toggle><?=t('Payments')?></a></li>
+                            <li><a href="#settings-order-statuses" data-pane-toggle><?=t('Order Statuses')?></a></li>
                             <li><a href="#settings-notifications" data-pane-toggle><?=t('Notifications')?></a></li>
                             <li><a href="#settings-products" data-pane-toggle><?=t('Products')?></a></li>
                         </ul>
@@ -167,8 +168,62 @@
                     ?>                                    
                     
             
-                </div><!-- #settings-notifications -->
-                
+                </div><!-- #settings-payments -->
+
+                <div class="col-sm-7 store-pane" id="settings-order-statuses">
+
+                    <?php
+                    if(count($orderStatuses)>0){ ?>
+                        <div class="panel panel-default">
+
+                            <table class="table" id="orderStatusTable">
+                                <thead>
+                                <tr>
+                                    <th rowspan="1">&nbsp;</th>
+                                    <th rowspan="1"><?php echo t('Display Name'); ?></th>
+                                    <th rowspan="1"><?php echo t('Default Status'); ?></th>
+                                    <th colspan="2" style="display:none;"><?php echo t('Send Change Notifications to...'); ?></th>
+                                </tr>
+                                <tr style="display:none;">
+                                    <th><?php echo t('Site'); ?></th>
+                                    <th><?php echo t('Customer'); ?></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <?php foreach($orderStatuses as $orderStatus){?>
+                                    <tr>
+                                        <td class="sorthandle"><input type="hidden" name="osID[]" value="<?php echo $orderStatus->getID(); ?>"><i class="fa fa-arrows-v"></i></td>
+                                        <td><input type="text" name="osName[]" value="<?php echo $orderStatus->getName(); ?>" placeholder="<?php echo $orderStatus->getReadableHandle(); ?>" class="form-control ccm-input-text"></td>
+                                        <td><input type="radio" name="osIsStartingStatus" value="<?php echo $orderStatus->getID(); ?>" <?php echo $orderStatus->isStartingStatus() ? 'checked':''; ?>></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformSite[]" value="1" <?php echo $orderStatus->getInformSite() ? 'checked':''; ?> class="form-control"></td>
+                                        <td style="display:none;"><input type="checkbox" name="osInformCustomer[]" value="1" <?php echo $orderStatus->getInformCustomer() ? 'checked':''; ?> class="form-control"></td>
+                                    </tr>
+                                <?php } ?>
+                                </tbody>
+                            </table>
+                            <script>
+                                $(function(){
+                                    $('#orderStatusTable TBODY').sortable({
+                                        cursor: 'move',
+                                        opacity: 0.5,
+                                        handle: '.sorthandle'
+                                    });
+
+                                });
+
+                            </script>
+
+                        </div>
+
+                    <?php
+                    } else {
+                        echo t("No Order Statuses are available");
+                    }
+                    ?>
+
+
+                </div><!-- #settings-order-statuses -->
+
                 <div class="col-sm-7 store-pane" id="settings-notifications">
                 
                     <div class="form-group">

--- a/src/VividStore/Orders/Order.php
+++ b/src/VividStore/Orders/Order.php
@@ -20,6 +20,8 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\Item as OrderItem;
 use \Concrete\Package\VividStore\Src\Attribute\Value\StoreOrderValue as StoreOrderValue;
 use \Concrete\Package\VividStore\Src\VividStore\Payment\Method as PaymentMethod;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\History as OrderHistory;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 class Order extends Object
@@ -61,7 +63,7 @@ class Order extends Object
         $pmID = $pm->getPaymentMethodID();
         
         //add the order
-        $vals = array($uID,$now,'pending',$pmID,$shipping,$tax,$total);
+        $vals = array($uID,$now,OrderStatus::getStartingStatus()->getHandle(),$pmID,$shipping,$tax,$total);
         $db->Execute("INSERT INTO VividStoreOrder(cID,oDate,oStatus,pmID,oShippingTotal,oTax,oTotal) values(?,?,?,?,?,?,?)", $vals);
         $oID = $db->lastInsertId();
         $order = Order::getByID($oID);
@@ -174,16 +176,10 @@ class Order extends Object
     
     public function updateStatus($status)
     {
-        // create copy of order before update
-        $originalOrder = $this;
-
-        Database::get()->Execute("UPDATE VividStoreOrder SET oStatus = ? WHERE oID = ?",array($status,$this->oID));
-
-        // update status of current order instance
-        $this->oStatus = $status;
-        // create event object, passing in changed and pre-change order
-        $event = new OrderEvent($this,$originalOrder);
-        Events::dispatch('on_vividstore_order_status_update', $event);
+        OrderHistory::updateOrderStatusHistory($this, $status);
+    }
+    public function getStatusHistory() {
+        return OrderHistory::getForOrder($this);
     }
     public function setAttribute($ak, $value)
     {

--- a/src/VividStore/Orders/OrderStatus/History.php
+++ b/src/VividStore/Orders/OrderStatus/History.php
@@ -1,0 +1,119 @@
+<?php
+namespace Concrete\Package\VividStore\src\VividStore\Orders\OrderStatus;
+
+use \Concrete\Core\Foundation\Object as Object;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderEvent;
+use Concrete\Package\VividStore\src\VividStore\Orders\Order;
+use Database;
+use Events;
+use User;
+
+class History extends Object
+{
+    public static $table = 'VividStoreOrderStatusHistory';
+
+    public function getOrderID() {
+        return $this->oID;
+    }
+
+    public function getOrder() {
+        return Order::getByID($this->getOrderID());
+    }
+
+    public function getOrderStatusHandle() {
+        return $this->oshStatus;
+    }
+
+    public function getOrderStatus() {
+        return OrderStatus::getByHandle($this->getOrderStatusHandle());
+    }
+
+    public function getOrderStatusName() {
+        return $this->getOrderStatus()->getName();
+    }
+
+    public function getDate($format = 'm/d/Y H:i:s') {
+        return date($format, strtotime($this->oshDate));
+    }
+
+    public function getUserID() {
+        return $this->uID;
+    }
+
+    public function getUser() {
+        return User::getByUserID($this->getUserID());
+    }
+
+    public function getUserName() {
+        return $this->getUser()->getUserName();
+    }
+
+    private static function getTableName()
+    {
+        return self::$table;
+    }
+
+    private static function getByID($oshID)
+    {
+        $db = Database::get();
+        $data = $db->GetRow("SELECT * FROM " . self::getTableName() . " WHERE oshID=?", $oshID);
+        $history = null;
+        if (!empty($data)) {
+            $history = new History();
+            $history->setPropertiesFromArray($data);
+        }
+        return ($history instanceof History) ? $history : false;
+    }
+
+    public static function getForOrder(Order $order)
+    {
+        if (!$order->getOrderID()) {
+            return false;
+        }
+        $sql = "SELECT * FROM " . self::$table . " WHERE oID=? ORDER BY oshDate DESC";
+        $rows = Database::get()->getAll($sql, $order->getOrderID());
+        $history = array();
+        if (count($rows) > 0) {
+            foreach ($rows as $row) {
+                $history[] = self::getByID($row['oshID']);
+            }
+        }
+        return $history;
+    }
+
+    public static function updateOrderStatusHistory(Order $order, $statusHandle)
+    {
+        if ($order->getStatus()!=$statusHandle) {
+            $updatedOrder = clone $order;
+            $updatedOrder->oStatus = self::recordStatusChange($order, $statusHandle);
+            $event = new OrderEvent($updatedOrder, $order);
+            Events::dispatch('on_vividstore_order_status_update', $event);
+        }
+    }
+
+    private static function recordStatusChange(Order $order, $statusHandle)
+    {
+        $db = Database::get();
+        $newOrderStatus = OrderStatus::getByHandle($statusHandle);
+        $user = new user();
+
+        $statusHistorySql = "INSERT INTO " . self::$table . " SET oID=?, oshStatus=?, uID=?";
+        $statusHistoryValues = array(
+            $order->getOrderID(),
+            $newOrderStatus->getHandle(),
+            $user->uID
+        );
+        $db->Execute($statusHistorySql, $statusHistoryValues);
+
+        $updateOrderSql = "UPDATE VividStoreOrder SET oStatus = ? WHERE oID = ?";
+        $updateOrderValues = array(
+            $newOrderStatus->getHandle(),
+            $order->getOrderID()
+        );
+        $db->Execute($updateOrderSql, $updateOrderValues);
+
+        return $newOrderStatus->getHandle();
+    }
+
+}

--- a/src/VividStore/Orders/OrderStatus/OrderStatus.php
+++ b/src/VividStore/Orders/OrderStatus/OrderStatus.php
@@ -1,0 +1,192 @@
+<?php
+namespace Concrete\Package\VividStore\src\VividStore\Orders\OrderStatus;
+
+use \Concrete\Core\Foundation\Object as Object;
+use \Concrete\Core\Utility\Service\Text as TextHelper;
+use Database;
+
+class OrderStatus extends Object
+{
+
+    static protected $table = "VividStoreOrderStatus";
+    protected $osID, $osHandle, $osName, $osInformSite, $osInformCustomer, $osSortOrder;
+
+    static public function getTableName()
+    {
+        return self::$table;
+    }
+
+    public static function getByID($osID)
+    {
+        $db = Database::get();
+        $data = $db->GetRow("SELECT * FROM " . self::getTableName() . " WHERE osID=?", $osID);
+        $orderStatus = null;
+        if (!empty($data)) {
+            $orderStatus = new OrderStatus();
+            $orderStatus->setPropertiesFromArray($data);
+        }
+        return ($orderStatus instanceof OrderStatus) ? $orderStatus : false;
+    }
+
+    static public function getByHandle($osHandle)
+    {
+        $db = Database::get();
+        $data = $db->GetRow("SELECT osID FROM " . self::getTableName() . " WHERE osHandle=?", $osHandle);
+        return OrderStatus::getByID($data['osID']);
+
+    }
+
+    static public function getAll() {
+        $db = Database::get();
+        $rows = $db->GetAll("SELECT osID FROM " . self::getTableName() . " ORDER BY osSortOrder ASC, osID ASC");
+        $statuses = array();
+        if (count($rows)>0) {
+            foreach ($rows as $row) {
+                $statuses[] = self::getByID($row['osID']);
+            }
+        }
+        return $statuses;
+    }
+
+    static public function getList()
+    {
+        $statuses = array();
+        foreach (self::getAll() as $status) {
+            $statuses[$status->getHandle()] = $status->getName();
+        }
+        return $statuses;
+    }
+
+    static public function add($osHandle, $osName = null, $osInformSite = 1, $osInformCustomer = 1, $osIsStartingStatus=0)
+    {
+        if (is_null($osName)) {
+            $textHelper = new TextHelper();
+            $osName = $textHelper->unhandle($osHandle);
+        }
+        $db = Database::get();
+        $sql = "INSERT INTO " . self::getTableName() . " (osHandle, osName, osInformSite, osInformCustomer) VALUES (?, ?, ?, ?)";
+        $values = array(
+            $osHandle,
+            $osName,
+            $osInformSite ? 1 : 0,
+            $osInformCustomer ? 1 : 0
+        );
+        $db->Execute($sql, $values);
+
+        if ($osIsStartingStatus) {
+            self::setNewStartingStatus($osHandle);
+        }
+    }
+
+    public function getID()
+    {
+        return $this->osID;
+    }
+
+    public function getHandle()
+    {
+        return $this->osHandle;
+    }
+
+    public function getReadableHandle()
+    {
+        $textHelper = new TextHelper();
+        return $textHelper->unhandle($this->osHandle);
+    }
+    public function getName()
+    {
+        return $this->osName;
+    }
+
+    public function setName($value = null)
+    {
+        if ($value) {
+            $this->setColumn('osName', $value);
+            return $value;
+        }
+        return null;
+    }
+
+    public function getInformSite()
+    {
+        return $this->osInformSite ? true : false;
+    }
+
+    public function setInformSite($value = true)
+    {
+        $this->setColumn('osInformSite', $value ? 1 : 0);
+        return $value ? true : false;
+    }
+
+    public function getInformCustomer()
+    {
+        return $this->osInformCustomer ? true : false;
+    }
+
+    public function setInformCustomer($value = true)
+    {
+        $this->setColumn('osInformCustomer', $value ? 1 : 0);
+        return $value ? true : false;
+    }
+
+    public function isStartingStatus()
+    {
+        return $this->osIsStartingStatus ? true : false;
+    }
+
+    public static function getStartingStatus() {
+        $statuses = self::getAll();
+        $startingStatus = $statuses[0];
+        foreach ($statuses as $status) {
+            if ($status->isStartingStatus()) {
+                $startingStatus = $status;
+                break;
+            }
+        }
+        return $startingStatus;
+    }
+
+    private function setColumn($column, $value)
+    {
+        $sql = "UPDATE " . self::getTableName() . " SET " . $column . "=? WHERE osID=?";
+        Database::get()->Execute($sql, array($column, $value));
+    }
+
+    public static function setNewStartingStatus($osHandle=null) {
+        if ($osHandle) {
+            $currentStartingStatus = self::getByHandle($osHandle);
+            if ($currentStartingStatus) {
+                $db = Database::get();
+                $db->Execute("UPDATE " . self::getTableName() . " SET osIsStartingStatus=0 WHERE 1=1");
+                $db->Execute("UPDATE " . self::getTableName() . " SET osIsStartingStatus=1 WHERE osHandle=?", array($osHandle));
+            }
+        }
+    }
+    public function update($data = array(), $ignoreFilledColumns = false)
+    {
+        $orderStatusArray = array(
+            'osHandle'=>$this->osHandle,
+            'osName'=>$this->osName,
+            'osInformSite'=>$this->osInformSite,
+            'osInformCustomer'=>$this->osInformCustomer,
+            'osSortOrder'=>$this->osSortOrder
+        );
+        $startingStatusHandle = null;
+        if (isset($data['osIsStartingStatus'])) {
+            $startingStatusHandle = $this->osHandle;
+        }
+        $orderStatusUpdateColumns = $ignoreFilledColumns ? array_diff($orderStatusArray, $data) : array_merge($orderStatusArray, $data);
+        unset($orderStatusUpdateColumns['osID']);
+        if (count($orderStatusUpdateColumns) > 0) {
+            $columnPhrase = implode('=?, ', array_keys($orderStatusUpdateColumns)) . "=?";
+            $values = array_values($orderStatusUpdateColumns);
+            $values[] = $this->osID;
+            Database::get()->Execute("UPDATE " . self::getTableName() . " SET " . $columnPhrase . " WHERE osID=?", $values);
+            if ($startingStatusHandle) {
+                OrderStatus::setNewStartingStatus($startingStatusHandle);
+            }
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Change order statues from being hardcoded to storing them in the DB.
- Can change the status names in the Settings page
- Can set the default status to be used when an Order is made
- Created the src\VividStore\Orders\OrderStatus\OrderStatus class
  - Started functionality to allow for emailing both the site and the customer when a status is changed, but it is not live in this update.
- Moved updates to Order History into a new class at src\VividStore\Orders\OrderStatus\History. 
  - The 'on_vividstore_order_status_update' event was moved to this class
  - Status, date/time and user are recorded in the history

New feature: Order Status History in the Order View.
- Moved the 'update status' next to the order status history table in the Order view
