### PR TITLE
Order item tax recording

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -28,13 +28,10 @@ defined('C5_EXECUTE') or die(_("Access Denied."));
 
 class Controller extends Package
 {
-
     protected $pkgHandle = 'vivid_store';
     protected $appVersionRequired = '5.7.3';
-    protected $pkgVersion = '2.0.7';
-    
-    
-    
+    protected $pkgVersion = '2.0.9.1';
+
     public function getPackageDescription()
     {
         return t("Add a Store to your Site");

--- a/db.xml
+++ b/db.xml
@@ -64,6 +64,7 @@
         <field name="smID" type="I"></field>
         <field name="oShippingTotal" type="C" size="10"></field>
         <field name="oTax" type="C" size="10"></field>
+        <field name="oTaxName" type="C" size="255"></field>
         <field name="oTotal" type="C" size="10"></field>
     </table>
     <table name="VividStoreOrderStatus">
@@ -87,7 +88,10 @@
         <field name="pID" type="I"></field>
         <field name="oID" type="I"></field>
         <field name="oiProductName" type="C" size="255"></field>
-        <field name="oiPricePaid" type="N" size="10,4"></field>
+        <field name="oiPricePaid" type="N" size="10.4"></field>
+        <field name="oiTax" type="N" size="10.4"></field>
+        <field name="oiTaxIncluded" type="N" size="10.4"></field>
+        <field name="oiTaxName" type="C" size="255"></field>
         <field name="oiQty" type="I"></field>
     </table>
     <table name="VividStoreOrderItemOption">

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -204,6 +204,40 @@ class Cart
         //return self::isCustomerTaxable();
         return Price::format($taxtotal);     
     }
+
+    public function getTaxProduct($productID)
+    {
+        $pkg = Package::getByHandle('vivid_store');
+        $pkgconfig = $pkg->getConfig();
+        //first check if tax is enabled in settings
+        if($pkgconfig->get('vividstore.taxenabled') == "yes"){
+            $cart = Session::get('cart');
+
+            if($cart){
+                foreach ($cart as $cartItem){
+                    if ($cartItem['product']['pID'] == $productID) {
+                        $product = VividProduct::getByID($productID);
+                    }
+
+                    if(is_object($product)){
+                        if($product->isTaxable()){
+                            //the product is "Taxable", but is the customer?
+                            if(self::isCustomerTaxable()){
+                                    $taxrate = $pkgconfig->get('vividstore.taxrate') / 100;
+                                    $tax = $taxrate *  $product->getProductPrice() ;
+                                    return $tax;
+
+                            }//if customer is taxable
+                        }//if product is taxable
+                    }//if obj
+                }//foreach
+            }//if cart
+        }//if tax enabled
+
+        return Price::format(0);
+    }
+
+
     public function getTotalItemsInCart(){
         $total = 0;    
         if(Session::get('cart')){

--- a/src/VividStore/Orders/Order.php
+++ b/src/VividStore/Orders/Order.php
@@ -17,11 +17,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 use \Concrete\Package\VividStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKey;
 use \Concrete\Package\VividStore\Src\VividStore\Cart\Cart as VividCart;
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
-use \Concrete\Package\VividStore\Src\VividStore\Orders\Item as OrderItem;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderItem as OrderItem;
 use \Concrete\Package\VividStore\Src\Attribute\Value\StoreOrderValue as StoreOrderValue;
 use \Concrete\Package\VividStore\Src\VividStore\Payment\Method as PaymentMethod;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\History as OrderHistory;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
+use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderEvent as OrderEvent;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 class Order extends Object
@@ -57,14 +58,15 @@ class Order extends Object
         //get the price details
         $shipping = VividCart::getShippingTotal();
         $tax = VividCart::getTaxTotal();
+        $taxName = ''; // for future addition
         $total = VividCart::getTotal();
         
         //get payment method
         $pmID = $pm->getPaymentMethodID();
         
         //add the order
-        $vals = array($uID,$now,OrderStatus::getStartingStatus()->getHandle(),$pmID,$shipping,$tax,$total);
-        $db->Execute("INSERT INTO VividStoreOrder(cID,oDate,oStatus,pmID,oShippingTotal,oTax,oTotal) values(?,?,?,?,?,?,?)", $vals);
+        $vals = array($uID,$now,OrderStatus::getStartingStatus()->getHandle(),$pmID,$shipping,$tax,$taxName,$total);
+        $db->Execute("INSERT INTO VividStoreOrder(cID,oDate,oStatus,pmID,oShippingTotal,oTax,oTaxName,oTotal) values(?,?,?,?,?,?,?,?)", $vals);
         $oID = $db->lastInsertId();
         $order = Order::getByID($oID);
         $order->setAttribute("billing_first_name",$ui->getAttribute("billing_first_name"));
@@ -78,7 +80,11 @@ class Order extends Object
         //add the order items
         $cart = Session::get('cart');
         foreach($cart as $cartItem){
-            OrderItem::add($cartItem,$oID);
+            $tax = VividCart::getTaxProduct($cartItem['product']['pID']);
+            $taxIncluded = 0;  // setting 0
+            $taxName = '';  // for future population
+
+            OrderItem::add($cartItem,$oID,$tax,$taxIncluded,$taxName);
 
             $product = VividProduct::getByID($cartItem['product']['pID']);
             if($product && $product->hasUserGroups()){

--- a/src/VividStore/Orders/OrderItem.php
+++ b/src/VividStore/Orders/OrderItem.php
@@ -8,18 +8,18 @@ use UserInfo;
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 defined('C5_EXECUTE') or die(_("Access Denied."));
-class Item extends Object
+class OrderItem extends Object
 {
     public static function getByID($oiID) {
         $db = Database::get();
         $data = $db->GetRow("SELECT * FROM VividStoreOrderItem WHERE oiID=?",$oiID);
         if(!empty($data)){
-            $item = new Item();
+            $item = new OrderItem();
             $item->setPropertiesFromArray($data);
         }
         return($item instanceof Item) ? $item : false;
     }  
-    public function add($data,$oID)
+    public function add($data,$oID,$tax=0,$taxIncluded=0,$taxName='')
     {
         $db = Database::get();
         $product = VividProduct::getByID($data['product']['pID']);
@@ -30,8 +30,8 @@ class Item extends Object
         $newStock = $inStock - $qty;
         $product->setProductQty($newStock);
         $pID = $product->getProductID();
-        $values = array($oID,$pID,$productName,$productPrice,$qty);
-        $db->Execute("INSERT INTO VividStoreOrderItem(oID,pID,oiProductName,oiPricePaid,oiQty) values(?,?,?,?,?)",$values);
+        $values = array($oID,$pID,$productName,$productPrice,$tax,$taxIncluded,$taxName,$qty);
+        $db->Execute("INSERT INTO VividStoreOrderItem(oID,pID,oiProductName,oiPricePaid,oiTax,oiTaxIncluded,oiTaxName,oiQty) values(?,?,?,?,?,?,?,?)",$values);
         
         $oiID = $db->lastInsertId();
         


### PR DESCRIPTION
This adds order item tax fields (one now that can record the tax added, another in the future that would be used instead if the tax was already included and a third for the future to record a tax name/label).

This also corrects the precision on the oiPricePaid field.

Finally, I renamed Item class to OrderItem for consistency with the way other classes are named,
