### PR TITLE
Dashboard orders search (plus a few tweaks to product search)

### DIFF
--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -13,16 +13,33 @@ defined('C5_EXECUTE') or die("Access Denied.");
 class Orders extends DashboardPageController
 {
 
-    public function view()
+    public function view($status = '')
     {
-        $orderList = new OrderList();       
+        $orderList = new OrderList();
+
+        if ($this->get('keywords')) {
+            $orderList->setSearch($this->get('keywords'));
+        }
+
+        if ($status) {
+            $orderList->setStatus($status);
+        }
+
         $orderList->setItemsPerPage(20);
+
         $paginator = $orderList->getPagination();
         $pagination = $paginator->renderDefaultView();
         $this->set('orderList',$paginator->getCurrentPageResults());  
         $this->set('pagination',$pagination);
         $this->set('paginator', $paginator);     
         $this->set('orderStatuses', OrderStatus::getList());
+        $pkg = Package::getByHandle('vivid_store');
+        $packagePath = $pkg->getRelativePath();
+        $this->addHeaderItem(Core::make('helper/html')->css($packagePath.'/css/vividStoreDashboard.css'));
+        $this->addFooterItem(Core::make('helper/html')->javascript($packagePath.'/js/vividStoreFunctions.js'));
+
+        $this->set('statuses', OrderStatus::getAll());
+
     }
     public function order($oID)
     {

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -170,33 +170,74 @@ defined('C5_EXECUTE') or die("Access Denied.");
     
     
 <?php } else { ?>
-<table class="table table-striped">
-    <thead>
-        <th><?=t("Order %s","#")?></th>
-        <th><?=t("Customer Name")?></th>
-        <th><?=t("Order Date")?></th>
-        <th><?=t("Total")?></th>
-        <th><?=t("Status")?></th>
-        <th><?=t("View")?></th>
-    </thead>
-    <tbody>
-        <?php
-            foreach($orderList as $order){
-        ?>
-            <tr>
-                <td><a href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=$order->getOrderID()?></a></td>
-                <td><?=$order->getAttribute('billing_last_name').", ".$order->getAttribute('billing_first_name')?></td>
-                <td><?=$order->getOrderDate()?></td>
-                <td><?=$order->getTotal()?></td>
-                <td><?=ucwords($order->getStatus())?></td>
-                <td><a class="btn btn-primary" href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=t("View")?></a></td>
-            </tr>
-        <?php } ?>
-    </tbody>
-</table>
+
+    <div class="ccm-dashboard-header-buttons">
+    </div>
+
+<div class="ccm-dashboard-content-full">
+    <form role="form" class="form-inline ccm-search-fields">
+        <div class="ccm-search-fields-row">
+            <?php if($statuses){?>
+                <ul id="group-filters" class="nav nav-pills">
+                    <li><a href="<?php echo View::url('/dashboard/store/orders/')?>"><?=t('All Statuses')?></a></li>
+                    <?php foreach($statuses as $status){ ?>
+                        <li><a href="<?php echo View::url('/dashboard/store/orders/', $status->getHandle())?>"><?=$status->getReadableHandle();?></a></li>
+                    <?php } ?>
+                </ul>
+            <?php } ?>
+        </div>
+
+
+        <div class="ccm-search-fields-row ccm-search-fields-submit">
+            <div class="form-group">
+                <div class="ccm-search-main-lookup-field">
+                    <i class="fa fa-search"></i>
+                    <?php echo $form->search('keywords', $searchRequest['keywords'], array('placeholder' => t('Search Orders')))?>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary pull-right"><?php echo t('Search')?></button>
+
+        </div>
+
+    </form>
+
+    <table class="ccm-search-results-table">
+        <thead>
+            <th><a><?=t("Order %s","#")?></a></th>
+            <th><a><?=t("Customer Name")?></a></th>
+            <th><a><?=t("Order Date")?></a></th>
+            <th><a><?=t("Total")?></a></th>
+            <th><a><?=t("Status")?></a></th>
+            <th><a><?=t("View")?></a></th>
+        </thead>
+        <tbody>
+            <?php
+                foreach($orderList as $order){
+            ?>
+                <tr>
+                    <td><a href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=$order->getOrderID()?></a></td>
+                    <td><?=$order->getAttribute('billing_last_name').", ".$order->getAttribute('billing_first_name')?></td>
+                    <td><?=$order->getOrderDate()?></td>
+                    <td><?=$order->getTotal()?></td>
+                    <td><?=ucwords($order->getStatus())?></td>
+                    <td><a class="btn btn-primary" href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=t("View")?></a></td>
+                </tr>
+            <?php } ?>
+        </tbody>
+    </table>
+</div>
 
 <?php if ($paginator->getTotalPages() > 1) { ?>
     <?= $pagination ?>
 <?php } ?>
 
 <?php } ?>
+
+<style>
+    @media (max-width: 992px) {
+        div#ccm-dashboard-content div.ccm-dashboard-content-full {
+            margin-left: -20px !important;
+            margin-right: -20px !important;
+        }
+    }
+</style>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -612,7 +612,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 	    </div>
 
     <div class="ccm-dashboard-content-full">
-        <form role="form" data-search-form="users"   class="form-inline ccm-search-fields">
+        <form role="form" class="form-inline ccm-search-fields">
             <div class="ccm-search-fields-row">
                 <?php if($grouplist){?>
                     <ul id="group-filters" class="nav nav-pills">
@@ -623,18 +623,17 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     </ul>
                 <?php } ?>
             </div>
-            <div class="ccm-search-fields-row">
+            <div class="ccm-search-fields-row ccm-search-fields-submit">
                 <div class="form-group">
                     <div class="ccm-search-main-lookup-field">
                         <i class="fa fa-search"></i>
                         <?php echo $form->search('keywords', $searchRequest['keywords'], array('placeholder' => t('Search Products')))?>
                     </div>
-                </div>
-            </div>
 
-            <div class="ccm-search-fields-row ccm-search-fields-submit">
+                </div>
                 <button type="submit" class="btn btn-primary pull-right"><?php echo t('Search')?></button>
             </div>
+
         </form>
 
         <table class="ccm-search-results-table">
@@ -732,3 +731,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
         </form>
         
     <?php }  ?>
+
+<style>
+    @media (max-width: 992px) {
+        div#ccm-dashboard-content div.ccm-dashboard-content-full {
+            margin-left: -20px !important;
+            margin-right: -20px !important;
+        }
+    }
+</style>

--- a/src/VividStore/Orders/Order.php
+++ b/src/VividStore/Orders/Order.php
@@ -24,7 +24,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Customer\Customer as Customer;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderEvent as OrderEvent;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\History as OrderHistory;
 use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderStatus\OrderStatus;
-use \Concrete\Package\VividStore\Src\VividStore\Orders\OrderEvent as OrderEvent;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 class Order extends Object

--- a/src/VividStore/Orders/OrderList.php
+++ b/src/VividStore/Orders/OrderList.php
@@ -22,8 +22,37 @@ class OrderList  extends AttributedItemList
     {
         $this->query
         ->select('o.oID')
-        ->from('VividStoreOrder','o')
-        ->orderBy('oID', 'DESC');
+        ->from('VividStoreOrder','o');
+
+    }
+
+    public function finalizeQuery(\Doctrine\DBAL\Query\QueryBuilder $query)
+    {
+        $paramcount = 0;
+
+        if (isset($this->search)) {
+            $this->query->where('oID like ?')->setParameter($paramcount++,'%'. $this->search. '%');
+        }
+
+        if(isset($this->status)){
+            if ($paramcount > 0) {
+                $this->query->andWhere('oStatus = ?')->setParameter($paramcount++,$this->status);
+            } else {
+                $this->query->where('oStatus = ?')->setParameter($paramcount++,$this->status);
+            }
+        }
+
+        $this->query->orderBy('oID', 'DESC');
+
+        return $this->query;
+    }
+
+    public function setSearch($search) {
+        $this->search = $search;
+    }
+
+    public function setStatus($status) {
+        $this->status = $status;
     }
     
     public function getResult($queryRow)


### PR DESCRIPTION
This reformats the orders list in the dashboard and adds filtering by order status and searching.

The order searching is _just_ Order IDs right now, so it's not 100% complete - I simply wasn't sure how to approach searching the associated order attributes, but thought this was at least a good start.
