### PR TITLE
Tax handling refinements

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -34,7 +34,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'vivid_store';
     protected $appVersionRequired = '5.7.3';
-    protected $pkgVersion = '2.1';
+    protected $pkgVersion = '2.1.1';
 
     public function getPackageDescription()
     {

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -47,12 +47,10 @@ class Checkout extends PageController
         $taxBased = $pkgconfig->get('vividstore.taxBased');
         $taxlabel = $pkgconfig->get('vividstore.taxName');
 
-
         $this->set('taxlabel',$taxlabel);
-
         $this->set('taxbased',$taxBased);
-        $this->set('hastax', !empty($totals['taxes']));
         $this->set('taxtotal',$totals['taxTotal']);
+
         $this->set('shippingtotal',$totals['shippingTotal']);
         $this->set('total',$totals['total']);
 

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -35,10 +35,27 @@ class Checkout extends PageController
         $this->set('form',Core::make("helper/form"));
         $this->set("countries",Core::make('helper/lists/countries')->getCountries());
         $this->set("states",Core::make('helper/lists/states_provinces')->getStates());
-        $this->set('subtotal',VividCart::getSubTotal());
-        $this->set('taxtotal',VividCart::getTaxTotal());
-        $this->set('shippingtotal',VividCart::getShippingTotal());
-        $this->set('total',VividCart::getTotal());
+
+        $totals = VividCart::getTotals();
+
+        $pkg = Package::getByHandle('vivid_store');
+        $pkgconfig = $pkg->getConfig();
+
+        $this->set('subtotal',$totals['subTotal']);
+        $this->set('taxes',$totals['taxes']);
+
+        $taxBased = $pkgconfig->get('vividstore.taxBased');
+        $taxlabel = $pkgconfig->get('vividstore.taxName');
+
+
+        $this->set('taxlabel',$taxlabel);
+
+        $this->set('taxbased',$taxBased);
+        $this->set('hastax', !empty($totals['taxes']));
+        $this->set('taxtotal',$totals['taxTotal']);
+        $this->set('shippingtotal',$totals['shippingTotal']);
+        $this->set('total',$totals['total']);
+
         $this->addHeaderItem("
             <script type=\"text/javascript\">
                 var PRODUCTMODAL = '".View::url('/productmodal')."';

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -73,6 +73,8 @@ class Settings extends DashboardPageController
                 $pkg->getconfig()->save('vividstore.taxMatch',trim($args['taxMatch']));
                 $pkg->getconfig()->save('vividstore.taxBased',trim($args['taxBased']));
                 $pkg->getconfig()->save('vividstore.taxrate',trim($args['taxRate']));
+                $pkg->getconfig()->save('vividstore.taxName',trim($args['taxName']));
+                $pkg->getconfig()->save('vividstore.calculation',trim($args['calculation']));
                 $pkg->getConfig()->save('vividstore.shippingenabled',$args['shippingEnabled']);
                 $pkg->getConfig()->save('vividstore.shippingbase',$args['shippingBasePrice']);
                 $pkg->getConfig()->save('vividstore.shippingitem',$args['shippingItemPrice']);
@@ -125,7 +127,7 @@ class Settings extends DashboardPageController
                 OrderStatus::setNewStartingStatus(OrderStatus::getByID($data['osIsStartingStatus'])->getHandle());
             } else {
                 $orderStatuses = OrderStatus::getAll();
-                OrderStatus::setNewStartingStatus($orderStatuses[0]);
+                OrderStatus::setNewStartingStatus($orderStatuses[0]->getHandle());
             }
         }
     }
@@ -139,12 +141,6 @@ class Settings extends DashboardPageController
         if($args['taxEnabled']=='yes'){
             if(!is_numeric(trim($args['taxRate']))){
                 $e->add(t('Tax Rate must be set, and a number'));
-            }
-            if($args['taxState']==""){
-                $e->add(t('Tax State must be set'));
-            }
-            if($args['taxCity']==""){
-                $e->add(t('Tax City must be set'));
             }
         }
         if($args['shippingEnabled']=='yes'){

--- a/db.xml
+++ b/db.xml
@@ -63,7 +63,8 @@
         <field name="pmID" type="I"></field>
         <field name="smID" type="I"></field>
         <field name="oShippingTotal" type="C" size="10"></field>
-        <field name="oTax" type="C" size="10"></field>
+        <field name="oTax" type="C" size="10.4"></field>
+        <field name="oTaxIncluded" type="N" size="10.4"></field>
         <field name="oTaxName" type="C" size="255"></field>
         <field name="oTotal" type="C" size="10"></field>
     </table>

--- a/js/vividStoreFunctions.js
+++ b/js/vividStoreFunctions.js
@@ -89,7 +89,13 @@ function updateTaxStates(){
        type: 'post',
        data: {country: countryCode, selectedState: selectedState, type: "tax"},
        success: function(states){
-            $("#taxState").replaceWith(states);
+           $("#taxState").replaceWith(states);
+
+           if (states.indexOf(" selected ") >= 0) {
+               $("#taxState").prepend("<option value=''></option>");
+           } else {
+               $("#taxState").prepend("<option value='' selected='selected'></option>");
+           }
        } 
     });
 }

--- a/mail/new_order_notification.php
+++ b/mail/new_order_notification.php
@@ -1,6 +1,6 @@
-<?php 
+<?php
 defined('C5_EXECUTE') or die("Access Denied.");
-
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 $subject = t("New Order Notification");
 
 
@@ -84,8 +84,8 @@ ob_start();
                                 ?>
                             </td>
                             <td><?=$item->getQty()?></td>
-                            <td><?=$item->getPricePaid()?></td>
-                            <td><?=$item->getSubTotal()?></td>
+                            <td><?=Price::format($item->getPricePaid())?></td>
+                            <td><?=Price::format($item->getSubTotal())?></td>
                         </tr>
                       <?php
                             }

--- a/mail/new_order_notification.php
+++ b/mail/new_order_notification.php
@@ -95,9 +95,20 @@ ob_start();
             </table>
             
             <p>
-                <strong><?=t("Tax")?>:</strong>  <?=$order->getTaxTotal()?><br>
-                <strong><?=t("Shipping")?>:</strong>  <?=$order->getShippingTotal()?><br>
-                <strong class="text-large"><?=t("Total")?>:</strong>  <?=$order->getTotal()?>
+                <?php
+                $taxtotal = $order->getTaxTotal();
+
+                if($taxtotal > 0 && $taxbased == 'subtotal') { ?>
+                    <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong>  <?=Price::format($order->getTaxTotal())?><br>
+                <?php } ?>
+
+                <strong><?=t("Shipping")?>:</strong>  <?=Price::format($order->getShippingTotal())?><br>
+
+                <?php if($taxtotal > 0 && $taxbased == 'grandtotal') { ?>
+                <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong>  <?=Price::format($order->getTaxTotal())?><br>
+                <?php } ?>
+
+                <strong class="text-large"><?=t("Total")?>:</strong>  <?=Price::format($order->getTotal())?>
             </p>
             
         </div>
@@ -125,4 +136,4 @@ ob_start();
 
 <?php 
 
-$body = ob_end_clean(); ?>
+$body = ob_get_clean(); ?>

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -1,6 +1,6 @@
 <?php 
 defined('C5_EXECUTE') or die("Access Denied.");
-
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 $subject = t("Order Receipt");
 
 

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -84,8 +84,8 @@ ob_start();
                                 ?>
                             </td>
                             <td><?=$item->getQty()?></td>
-                            <td><?=$item->getPricePaid()?></td>
-                            <td><?=$item->getSubTotal()?></td>
+                            <td><?=Price::format($item->getPricePaid())?></td>
+                            <td><?=Price::format($item->getSubTotal())?></td>
                         </tr>
                       <?php
                             }
@@ -122,9 +122,20 @@ ob_start();
             </div>
             
             <p>
-                <strong><?=t("Tax")?>:</strong>  <?=$order->getTaxTotal()?><br>
-                <strong><?=t("Shipping")?>:</strong>  <?=$order->getShippingTotal()?><br>
-                <strong class="text-large"><?=t("Total")?>:</strong>  <?=$order->getTotal()?>
+                <?php
+                $taxtotal = $order->getTaxTotal();
+
+                if($taxtotal > 0 && $taxbased == 'subtotal') { ?>
+                    <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong>  <?=Price::format($order->getTaxTotal())?><br>
+                <?php } ?>
+
+                <strong><?=t("Shipping")?>:</strong>  <?=Price::format($order->getShippingTotal())?><br>
+
+                <?php if($taxtotal > 0 && $taxbased == 'grandtotal') { ?>
+                    <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong>  <?=Price::format($order->getTaxTotal())?><br>
+                <?php } ?>
+
+                <strong class="text-large"><?=t("Total")?>:</strong>  <?=Price::format($order->getTotal())?>
             </p>
             
         </div>
@@ -174,10 +185,10 @@ ob_start();
     }
 ?>
 
-<?=t("Tax")?>: <?=$order->getTaxTotal()?>
-<?=t("Shipping")?>:  <?=$order->getShippingTotal()?>
-<?=t("Total")?>: <?=$order->getTotal()?>
+<?=t("Tax")?>: <?=Price::format($order->getTaxTotal())?>
+<?=t("Shipping")?>:  <?=Price::format($order->getShippingTotal())?>
+<?=t("Total")?>: <?=Price::format($order->getTotal())?>
 
 <?php 
 
-$body = ob_end_clean(); ?>
+$body = ob_get_clean(); ?>

--- a/single_pages/cart.php
+++ b/single_pages/cart.php
@@ -66,7 +66,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
     
     <div class="cart-page-cart-total">        
         <span class="cart-grand-total-label"><?=t("Sub Total")?>:</span>
-        <span class="cart-grand-total-value"><?=$total?></span>        
+        <span class="cart-grand-total-value"><?=Price::format($total)?></span>
     </div>
         
     <div class="cart-page-cart-links">

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -258,13 +258,13 @@ defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
         <p>
             <strong><?=t("Items Subtotal")?>:</strong> <?=Price::format($subtotal);?><br>
 
-            <?php if($hastax && $taxbased == 'subtotal') { ?>
+            <?php if($taxtotal > 0 && $taxbased == 'subtotal') { ?>
                 <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong> <span class="tax-amount"><?=Price::format($taxtotal);?></span><br>
             <?php } ?>
 
             <strong><?=t("Shipping")?>:</strong> <?=Price::format($shippingtotal);?><br>
 
-            <?php if($hastax && $taxbased == 'grandtotal') { ?>
+            <?php if($taxtotal > 0 && $taxbased == 'grandtotal') { ?>
                 <strong><?= ($taxlabel ? $taxlabel : t("Tax"))?>:</strong> <span class="tax-amount"><?=Price::format($taxtotal)?></span><br>
             <?php } ?>
 

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -1,4 +1,6 @@
-<?php defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
+<?php
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
+defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
 <?php if($controller->getTask() == "view" || $controller->getTask() == "failed"){?>
 
 <div class="clearfix">
@@ -254,11 +256,20 @@
         
         <h2><?=t("Cart Total")?></h2>
         <p>
-            <strong><?=t("Items Subtotal")?>:</strong> <?=$subtotal?><br>
-            <strong><?=t("Tax")?>:</strong> <span class="tax-amount"><?=$taxtotal?></span><br>
-            <strong><?=t("Shipping")?>:</strong> <?=$shippingtotal?>
+            <strong><?=t("Items Subtotal")?>:</strong> <?=Price::format($subtotal);?><br>
+
+            <?php if($hastax && $taxbased == 'subtotal') { ?>
+                <strong><?=($taxlabel ? $taxlabel : t("Tax"))?>:</strong> <span class="tax-amount"><?=Price::format($taxtotal);?></span><br>
+            <?php } ?>
+
+            <strong><?=t("Shipping")?>:</strong> <?=Price::format($shippingtotal);?><br>
+
+            <?php if($hastax && $taxbased == 'grandtotal') { ?>
+                <strong><?= ($taxlabel ? $taxlabel : t("Tax"))?>:</strong> <span class="tax-amount"><?=Price::format($taxtotal)?></span><br>
+            <?php } ?>
+
         </p>
-        <p><strong><?=t("Grand Total")?>:</strong> <span class="total-amount"><?=$total?></span></p>
+        <p><strong><?=t("Grand Total")?>:</strong> <span class="total-amount"><?=Price::format($total)?></span></p>
         
     </div>
 

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -97,8 +97,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
     </table>
     
     <p>
+        <strong><?=t("Items Subtotal")?>:</strong>  <?= Price::format($order->getSubTotal())?><br>
+        <?php $shipping = $order->getShippingTotal();
+        if ($shipping > 0) { ?>
+        <strong><?=t("Shipping")?>:</strong>  <?= Price::format($shipping)?><br>
+        <?php } ?>
         <strong><?=($order->oTaxName ? $order->oTaxName : t("Tax"))?>:</strong>  <?= Price::format($order->getTaxTotal())?><br>
-        <strong><?=t("Shipping")?>:</strong>  <?= Price::format($order->getShippingTotal())?><br>
         <strong class="text-large"><?=t("Total")?>:</strong>  <?= Price::format($order->getTotal())?><br>
         <strong><?=t("Payment Method")?>:</strong> <?=$order->getPaymentMethodName()?>
     </p>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -1,5 +1,6 @@
-<?php 
+<?php
 defined('C5_EXECUTE') or die("Access Denied.");
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 ?>
 
 <?php if ($controller->getTask() == 'order'){ ?>
@@ -48,7 +49,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
             </p>
         </div>
     </div>
-    <h3><?=t("Items Orders")?></h3>
+    <h3><?=t("Order Items")?></h3>
     <hr>
     <table class="table table-striped">
         <thead>
@@ -63,6 +64,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
         <tbody>
             <?php 
                 $items = $order->getOrderItems();
+
                 if($items){
                     foreach($items as $item){
               ?>
@@ -83,9 +85,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
                             }
                         ?>
                     </td>
-                    <td><?=$item->getPricePaid()?></td>
+                    <td><?=Price::format($item->getPricePaid())?></td>
                     <td><?=$item->getQty()?></td>
-                    <td><?=$item->getSubTotal()?></td>
+                    <td><?=Price::format($item->getSubTotal())?></td>
                 </tr>
               <?php
                     }
@@ -95,9 +97,9 @@ defined('C5_EXECUTE') or die("Access Denied.");
     </table>
     
     <p>
-        <strong><?=t("Tax")?>:</strong>  <?=$order->getTaxTotal()?><br>
-        <strong><?=t("Shipping")?>:</strong>  <?=$order->getShippingTotal()?><br>
-        <strong class="text-large"><?=t("Total")?>:</strong>  <?=$order->getTotal()?><br>
+        <strong><?=($order->oTaxName ? $order->oTaxName : t("Tax"))?>:</strong>  <?= Price::format($order->getTaxTotal())?><br>
+        <strong><?=t("Shipping")?>:</strong>  <?= Price::format($order->getShippingTotal())?><br>
+        <strong class="text-large"><?=t("Total")?>:</strong>  <?= Price::format($order->getTotal())?><br>
         <strong><?=t("Payment Method")?>:</strong> <?=$order->getPaymentMethodName()?>
     </p>
 
@@ -187,7 +189,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                 <td><a href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=$order->getOrderID()?></a></td>
                 <td><?=$order->getAttribute('billing_last_name').", ".$order->getAttribute('billing_first_name')?></td>
                 <td><?=$order->getOrderDate()?></td>
-                <td><?=$order->getTotal()?></td>
+                <td><?=Price::format($order->getTotal())?></td>
                 <td><?=ucwords($order->getStatus())?></td>
                 <td><a class="btn btn-primary" href="<?=View::url('/dashboard/store/orders/order/',$order->getOrderID())?>"><?=t("View")?></a></td>
             </tr>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -41,60 +41,63 @@
                 
                 <div class="col-sm-7 store-pane" id="settings-tax" data-states-utility="<?=View::url('/checkout/getstates')?>">
                 
-                    <h3><?=t("Your Store Location")?></h3>
-                    <div class="row">
-                        <div class="col-xs-12 col-sm-6">
+                    <h3><?=t("Tax Configuration")?></h3>
+                        <div class="row">
+                        <div class="col-xs-6">
                             <div class="form-group">
                                 <?php echo $form->label('taxEnabled',t('Enable Tax')); ?>
                                 <?php echo $form->select('taxEnabled',array('no'=>t('No'),'yes'=>t('Yes')),$pkgconfig->get('vividstore.taxenabled')); ?>
-                            </div>                            
-                        </div>
-                        <div class="col-xs-12 col-sm-6">
-                            <div class="form-group">
-                                <label for="taxCountry"><?=t("Country")?></label>
-                                <?php $country = $pkgconfig->get('vividstore.taxcountry'); ?>
-                                <?php echo $form->select('taxCountry',$countries,$country?$country:'US',array("onchange"=>"updateTaxStates()")); ?>
-                            </div>                            
-                        </div>
-                        <div class="col-xs-12 col-sm-6">
-                            <div class="form-group">
-                                <label for="taxState"><?=t("State/Region")?></label>
-                                <?php $state = $pkgconfig->get('vividstore.taxstate'); ?>
-                                <?php echo $form->select('taxState',$states,$state?$state:""); ?>
-                                <?php echo $form->hidden("savedTaxState",$state); ?>
                             </div>
                         </div>
-                        <div class="col-xs-12 col-sm-6">
+                        <div class="col-xs-6">
                             <div class="form-group">
-                                <?=$form->label('taxCity',t("City"))?>
-                                <?=$form->text('taxCity',$pkgconfig->get('vividstore.taxcity'));?>
+                                <?php echo $form->label('taxRate',t('Tax Rate %')); ?>
+                                <div class="input-group" style="width: 150px;">
+                                    <?php echo $form->text('taxRate',$pkgconfig->get('vividstore.taxrate')); ?>
+                                    <div class="input-group-addon">%</div>
+                                </div>
                             </div>
-                        </div>    
-                    </div>
-                    <hr>
-                    <h3><?=t("Tax Rules")?></h3>
-                    <div id="tax-rules-group" class="form form-inline">
-                        <div class="form-group">
-                            <label for="taxAddress"><?=t("I charge sales tax if the")?></label>
-                            <?php echo $form->select('taxAddress',array('shipping'=>t("Shipping Address"),'billing'=>t("Billing Address")),$pkgconfig->get('vividstore.taxAddress')); ?>
-                        </div>   
-                        <div class="form-group">
-                            <label for="taxMatch"><?=t("matches our")?></label>
-                            <?php echo $form->select('taxMatch',array('state'=>t("State/Region"),'city'=>t("City"),'country'=>t("Country")),$pkgconfig->get('vividstore.taxMatch')); ?>
-                        </div>    
-                        <div class="form-group">
-                            <label for="taxMatch"><?=t("based on the")?></label>
-                            <?php echo $form->select('taxBased',array('subtotal'=>t("Product Total"),'grandtotal'=>t("Product Total + Shipping")),$pkgconfig->get('vividstore.taxBased')); ?>
-                        </div>   
-                    </div>
+                        </div>
+                        </div>
+
                     <div class="form-group">
-                        <?php echo $form->label('taxRate',t('Tax Rate %')); ?>
-                        <div class="input-group" style="width: 150px;">
-                            <?php echo $form->text('taxRate',$pkgconfig->get('vividstore.taxrate')); ?>
-                            <div class="input-group-addon">%</div>
-                        </div>
+                        <label for="taxMatch"><?=t("Tax Name")?></label>
+                        <?php echo $form->text('taxName',$pkgconfig->get('vividstore.taxName'));?>
                     </div>
-                    
+
+                        <div class="form-group">
+                            <label for="taxMatch"><?=t("Based on the")?></label>
+                            <?php echo $form->select('taxBased',array('subtotal'=>t("Product Total"),'grandtotal'=>t("Product Total + Shipping")),$pkgconfig->get('vividstore.taxBased')); ?>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="taxMatch"><?=t("Tax is")?></label>
+                            <?php echo $form->select('calculation',array('add'=>t("Calculated from total and added to order"),'extract'=>t("Already in product prices, only display as component of total")),$pkgconfig->get('vividstore.calculation')); ?>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="taxAddress"><?=t("Tax is applicable if")?></label>
+                            <?php echo $form->select('taxAddress',array('shipping'=>t("Shipping Address"),'billing'=>t("Billing Address")),$pkgconfig->get('vividstore.taxAddress')); ?>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="taxCountry"><?=t("Matches the Country")?></label>
+                            <?php $country = $pkgconfig->get('vividstore.taxcountry'); ?>
+                            <?php echo $form->select('taxCountry',$countries,$country?$country:'US',array("onchange"=>"updateTaxStates()")); ?>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="taxState"><?=t("And optionally the State/Region")?></label>
+                            <?php $state = $pkgconfig->get('vividstore.taxstate'); ?>
+                            <?php echo $form->select('taxState',$states,$state?$state:"", array('disabled'=>'disabled','class'=>"form-control")); ?>
+                            <?php echo $form->hidden("savedTaxState",$state); ?>
+                        </div>
+
+                        <div class="form-group">
+                            <?=$form->label('taxCity',t("And optionally the City"))?>
+                            <?php echo $form->text('taxCity',$pkgconfig->get('vividstore.taxcity'));?>
+                        </div>
+
                 </div>
                                 
                 <div class="col-sm-7 store-pane" id="settings-shipping">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -63,6 +63,8 @@
                     <div class="form-group">
                         <label for="taxMatch"><?=t("Tax Name")?></label>
                         <?php echo $form->text('taxName',$pkgconfig->get('vividstore.taxName'));?>
+                        <span class="help-block"><?php  echo t('(optional, will default to \'tax\' if left blank)'); ?></span>
+
                     </div>
 
                         <div class="form-group">

--- a/src/VividStore/Cart/CartTotal.php
+++ b/src/VividStore/Cart/CartTotal.php
@@ -2,6 +2,7 @@
 namespace Concrete\Package\VividStore\Src\VividStore\Cart;
 
 use \Concrete\Core\Controller\Controller as RouteController;
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
 
 use \Concrete\Package\VividStore\Src\VividStore\Cart\Cart as VividCart;
 defined('C5_EXECUTE') or die(_("Access Denied."));
@@ -10,15 +11,15 @@ class CartTotal extends RouteController
         
     public function getSubTotal()
     {
-        echo VividCart::getSubTotal();
+        echo Price::format(VividCart::getSubTotal());
     }
     public function getTotal()
     {
-        echo VividCart::getTotal();
+        echo Price::format(VividCart::getTotal());
     }
     public function getTaxTotal()
     {
-        echo VividCart::getTaxTotal();
+        echo Price::format(VividCart::getTaxTotal());
     }
     public function getTotalItems()
     {

--- a/src/VividStore/Orders/OrderItem.php
+++ b/src/VividStore/Orders/OrderItem.php
@@ -17,7 +17,7 @@ class OrderItem extends Object
             $item = new OrderItem();
             $item->setPropertiesFromArray($data);
         }
-        return($item instanceof Item) ? $item : false;
+        return($item instanceof OrderItem) ? $item : false;
     }  
     public function add($data,$oID,$tax=0,$taxIncluded=0,$taxName='')
     {
@@ -65,14 +65,14 @@ class OrderItem extends Object
     }    
     
     public function getProductName(){ return $this->oiProductName; }
-    public function getPricePaid() { return Price::format($this->oiPricePaid); }
+    public function getPricePaid() { return $this->oiPricePaid; }
     public function getQty() { return $this->oiQty; }
     public function getSubTotal()
     {
         $price = Price::getFloat($this->getPricePaid());
         $qty = $this->getQty();
         $subtotal = $qty * $price;
-        return Price::format($subtotal);
+        return $subtotal;
     }
     public function getProductOptions()
     {

--- a/src/VividStore/Orders/OrderList.php
+++ b/src/VividStore/Orders/OrderList.php
@@ -7,7 +7,6 @@ use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
 
 use Concrete\Package\VividStore\Src\VividStore\Orders\Order as VividOrder;
-use Concrete\Package\VividStore\Src\VividStore\Orders\Item as OrderItem;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 class OrderList  extends AttributedItemList

--- a/src/VividStore/Utilities/Price.php
+++ b/src/VividStore/Utilities/Price.php
@@ -5,8 +5,7 @@ defined('C5_EXECUTE') or die(_("Access Denied."));
 
 class Price
 {
-    
-    public function format($price)
+    public static function format($price)
     {
         $pkg = Package::getByHandle('vivid_store');
         $symbol = $pkg->getConfig()->get('vividstore.symbol');
@@ -19,9 +18,9 @@ class Price
     {
         $pkg = Package::getByHandle('vivid_store');
         $pkgconfig = $pkg->getConfig();
-        $symbol = $pkg->getConfig()->get('vividstore.symbol');
-        $wholeSep = $pkg->getConfig()->get('vividstore.whole');
-        $thousandSep = $pkg->getConfig()->get('vividstore.thousand');
+        $symbol = $pkgconfig->get('vividstore.symbol');
+        $wholeSep = $pkgconfig->get('vividstore.whole');
+        $thousandSep = $pkgconfig->get('vividstore.thousand');
         
         $price = str_replace($wholeSep, ".", $price); // replace whole separator with '.' 
         $price = str_replace($thousandSep, "", $price); //no commas, or spaces or whatevz


### PR DESCRIPTION
- The ability to set tax to be calculated from total, or added to order
- Simplified (hopefully) set up of tax, does trickle down matching against country/state/town
- Tax name field (which carries through to checkout, emails and is stored against the order)
- Stores against the order a TaxIncluded value when appropriate (like it does for the individual items)
- Moved the formatting of values to view layer. 
- Created a function to return all cart values, so it's not doing calculations multiple times
- A couple of little fixes along the way (precision of tax against orders for example)

Resolves #35 
Resolves #33 
Resolves #7
