### PR TITLE
Add a Order Status History entry for new orders

### DIFF
--- a/src/VividStore/Orders/Order.php
+++ b/src/VividStore/Orders/Order.php
@@ -84,10 +84,11 @@ class Order extends Object
         $pmID = $pm->getPaymentMethodID();
 
         //add the order
-        $vals = array($customer->getUserID(),$now,OrderStatus::getStartingStatus()->getHandle(),$pmID,$shipping,$tax,$taxIncluded,$taxName,$total);
-        $db->Execute("INSERT INTO VividStoreOrder(cID,oDate,oStatus,pmID,oShippingTotal,oTax,oTaxIncluded,oTaxName,oTotal) values(?,?,?,?,?,?,?,?,?)", $vals);
+        $vals = array($customer->getUserID(),$now,$pmID,$shipping,$tax,$taxIncluded,$taxName,$total);
+        $db->Execute("INSERT INTO VividStoreOrder(cID,oDate,pmID,oShippingTotal,oTax,oTaxIncluded,oTaxName,oTotal) VALUES (?,?,?,?,?,?,?,?,?)", $vals);
         $oID = $db->lastInsertId();
         $order = Order::getByID($oID);
+        $order->updateStatus(OrderStatus::getStartingStatus()->getHandle());
         $order->setAttribute("email",$customer->getEmail());
         $order->setAttribute("billing_first_name",$customer->getValue("billing_first_name"));
         $order->setAttribute("billing_last_name",$customer->getValue("billing_last_name"));


### PR DESCRIPTION
Move the addition of status from the INSERT sql to a separate line so that the functionality of adding a history entry is triggered. This resolves issue #55 
