### PR TITLE
Bug fix when the price is a whole number

### DIFF
--- a/src/VividStore/Utilities/Price.php
+++ b/src/VividStore/Utilities/Price.php
@@ -12,7 +12,7 @@ class Price
         $symbol = $pkg->getConfig()->get('vividstore.symbol');
         $wholeSep = $pkg->getConfig()->get('vividstore.whole');
         $thousandSep = $pkg->getConfig()->get('vividstore.thousand');
-        $price = $symbol . number_format($price, 2, $wholeSep, $thousandSep);
+        $price = $symbol . number_format(floatval($price), 2, $wholeSep, $thousandSep);
         return $price;
     }   
     public function getFloat($price)


### PR DESCRIPTION
When the price is a whole number, the number_format() function errors out with a notice that the 1st argument is a string, but a float is expected.
