### PR TITLE
Checkout skips shipping form for orders with no shippable products.

### DIFF
--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -105,6 +105,7 @@ class Checkout extends PageController
 
         $this->set('shippingtotal',$totals['shippingTotal']);
         $this->set('total',$totals['total']);
+        $this->set('shippingEnabled', VividCart::isShippable());
 
         $this->addHeaderItem("
             <script type=\"text/javascript\">

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -123,7 +123,7 @@ defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
             </div>
             
         </form>
-        
+        <?php if ($shippingEnabled) { ?>
         <form class="checkout-form-group" id="checkout-form-group-shipping">
             
             <h2><?=t("Shipping Address")?></h2>
@@ -198,7 +198,6 @@ defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
             </div>
             
         </form>
-        
         <!--
         <div class="checkout-form-group" id="checkout-form-group-shipping-method">
             
@@ -206,7 +205,8 @@ defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
             
         </div>
         -->
-        
+      <?php } ?>
+
         <form class="checkout-form-group" id="checkout-form-group-payment" method="post" action="<?=View::url('/checkout/submit')?>">
             
             <h2><?=t("Payment")?></h2>
@@ -281,8 +281,9 @@ defined('C5_EXECUTE') or die(_("Access Denied.")); ?>
                 }
                 ?>
             </span>
+            <?php if ($shippingEnabled) { ?>
             <strong><?=t("Shipping")?>:</strong> <?=Price::format($shippingtotal);?><br>
-
+            <?php } ?>
         </p>
         <p><strong><?=t("Grand Total")?>:</strong> <span class="total-amount"><?=Price::format($total)?></span></p>
         

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -1,6 +1,7 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
+use \Concrete\Package\VividStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKey;
 ?>
 
 <?php if ($controller->getTask() == 'order'){ ?>
@@ -28,25 +29,18 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
             <h4><?=t("Billing Information")?></h4>
             <p>
                 <?=$order->getAttribute("billing_first_name"). " " . $order->getAttribute("billing_last_name")?><br>
-                <?=$order->getAttribute("billing_address")->address1?><br>
-                <?php if($order->getAttribute("billing_address")->address2){
-                    echo $order->getAttribute("billing_address")->address2 . "<br>";
-                } ?>
-                <?=$order->getAttribute("billing_address")->city?>, <?=$order->getAttribute("billing_address")->state_province?> <?=$order->getAttribute("billing_address")->postal_code?><br>
-                <?=$order->getAttribute("billing_phone")?>
+                <?=$order->getAttributeValueObject(StoreOrderKey::getByHandle('billing_address'))->getValue('displaySanitized', 'display'); ?>
+                <br /> <br /><?php echo t('Phone'); ?>: <?=$order->getAttribute("billing_phone")?>
             </p>
         </div>
         <div class="col-sm-6">
+            <?php if ($order->getAttribute("shipping_address")->address1) { ?>
             <h4><?=t("Shipping Information")?></h4>
             <p>
                 <?=$order->getAttribute("shipping_first_name"). " " . $order->getAttribute("shipping_last_name")?><br>
-                <?=$order->getAttribute("shipping_address")->address1?><br>
-                <?php if($order->getAttribute("shipping_address")->address2){
-                    echo $order->getAttribute("shipping_address")->address2 . "<br>";
-                } ?>
-                <?=$order->getAttribute("shipping_address")->city?>, <?=$order->getAttribute("shipping_address")->state_province?> <?=$order->getAttribute("shipping_address")->postal_code?><br>
-                
+                <?=$order->getAttributeValueObject(StoreOrderKey::getByHandle('shipping_address'))->getValue('displaySanitized', 'display'); ?>
             </p>
+            <?php } ?>
         </div>
     </div>
     <h3><?=t("Order Items")?></h3>

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -255,6 +255,18 @@ class Cart
         }
         return $total;
     }
+
+    public function isShippable() {
+        foreach(Session::get('cart') as $item){
+            //check if items are shippable
+            $product = VividProduct::getByID($item['product']['pID']);
+            if($product->isShippable()){
+               return true; // return as soon as we have shippable product
+            }
+        }
+        return false;
+    }
+
     public function getShippingTotal(){
         $shippingenabled = Config::get('vividstore.shippingenabled');
         if($shippingenabled=="yes"){


### PR DESCRIPTION
Addresses #72 

This also simplifies the order details screen in the dashboard - it uses the built-in render of the address attributes instead of manually building up the address (I noticed it wasn't outputting the country code, so thought to swap over to this as opposed to having to do a country code lookup)
