### PR TITLE
Multiple product group assigning/filtering

### DIFF
--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -5,6 +5,8 @@ use Package;
 use Core;
 use View;
 use Page;
+use Database;
+use Log;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductList as VividProductList;
 use \Concrete\Package\VividStore\Src\VividStore\Groups\ProductGroup as VividProductGroup;
 use \Concrete\Package\VividStore\Src\VividStore\Groups\GroupList as VividProductGroupList;
@@ -29,34 +31,73 @@ class Controller extends BlockController
     }
     public function add()
     {
+        $this->requireAsset('css', 'select2');
+        $this->requireAsset('javascript', 'select2');
         $this->getGroupList();
+        $this->set('groupfilters', array());
     }
     public function edit()
     {
+        $this->requireAsset('css', 'select2');
+        $this->requireAsset('javascript', 'select2');
         $this->getGroupList();
+        $this->set('groupfilters', $this->getGroupFilters());
     }
+
+    public function getGroupFilters() {
+        $db = Database::get();
+        $vals = array($this->bID);
+        $result = $db->getAll("SELECT gID FROM btVividStoreProductListGroups where bID = ?",$vals);
+
+        $list = array();
+
+        if ($result) {
+            foreach($result as $g) {
+                $list[] = $g['gID'];
+            }
+        }
+
+        return $list;
+
+    }
+
     public function getGroupList()
     {
-        $grouplist = VividProductGroupList::getGroupList();            
+        $grouplist = VividProductGroupList::getGroupList();
         $this->set("grouplist",$grouplist);
     }
     public function view()
     {
-        
         $products = new VividProductList();
 
-        if ($this->filter == 'page' || $this->filter == 'page_children') {
+        if ($this->filter == 'current' || $this->filter == 'current_children') {
             $page = Page::getCurrentPage();
             $products->setCID($page->getCollectionID());
 
-            if ($this->filter == 'page_children') {
+            if ($this->filter == 'current_children') {
                 $products->setCIDs($page->getCollectionChildrenArray());
             }
         }
 
+
+        if ($this->filter == 'page' || $this->filter == 'page_children') {
+            if ($this->filterCID) {
+                $products->setCID($this->filterCID);
+
+                if ($this->filter == 'page_children') {
+                    $targetpage = Page::getByID($this->filterCID);
+                    if ($targetpage) {
+                        $products->setCIDs($targetpage->getCollectionChildrenArray());
+                    }
+                }
+            }
+        }
+
+
         $products->setItemsPerPage($this->maxProducts);
-        $products->setGroupID($this->gID);
+        $products->setGroupIDs($this->getGroupFilters());
         $products->setFeatureType($this->showFeatured);
+        $products->setGroupMatchAny($this->groupMatchAny);
         $paginator = $products->getPagination();
         $pagination = $paginator->renderDefaultView();
         $this->set('products',$paginator->getCurrentPageResults());  
@@ -95,15 +136,37 @@ class Controller extends BlockController
         $args['showButton'] = isset($args['showButton']) ? 1 : 0;
         $args['truncateEnabled'] = isset($args['truncateEnabled']) ? 1 : 0;
         $args['showPagination'] = isset($args['showPagination']) ? 1 : 0;
+
+        $filtergroups = $args['filtergroups'];
+        unset($args['filtergroups']);
+
+        $db = Database::get();
+        $vals = array($this->bID);
+        $db->Execute("DELETE FROM btVividStoreProductListGroups where bID = ?",$vals);
+
+        //insert  groups
+        if (!empty($filtergroups)) {
+            foreach($filtergroups as $gID){
+                $vals = array($this->bID,(int)$gID);
+                Log::addEntry($vals);
+                $db->Execute("INSERT INTO btVividStoreProductListGroups (bID,gID) VALUES (?,?)",$vals);
+            }
+        }
+
         parent::save($args);
     }
     public function validate($args)
     {
-        $e = Core::make("helper/validation/error"); 
+        $e = Core::make("helper/validation/error");
         $nh = Core::make("helper/number");
         if($args['maxProducts'] < 1){
             $e->add(t('Max Products must be at least 1'));
         }
+
+        if(($args['filter'] == 'page' || $args['filter'] == 'page_children') && $args['filterCID'] <= 0){
+            $e->add(t('A page must be selected'));
+        }
+
         if(!$nh->isInteger($args['maxProducts'])){
             $e->add(t('Max Product must be a whole number'));
         }

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -6,7 +6,6 @@ use Core;
 use View;
 use Page;
 use Database;
-use Log;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductList as VividProductList;
 use \Concrete\Package\VividStore\Src\VividStore\Groups\ProductGroup as VividProductGroup;
 use \Concrete\Package\VividStore\Src\VividStore\Groups\GroupList as VividProductGroupList;

--- a/blocks/vivid_product_list/db.xml
+++ b/blocks/vivid_product_list/db.xml
@@ -8,6 +8,8 @@
 		<field name="sortOrder" type="C" size="30"></field>
 		<field name="gID" type="I"><unsigned/></field>
 		<field name="filter" type="C" size="30"></field>
+		<field name="filterCID" type="I"><unsigned/></field>
+		<field name="groupMatchAny" type="L"></field>
 		<field name="maxProducts" type="I"><unsigned/></field>
 		<field name="productsPerRow" type="I"><unsigned/></field>
 		<field name="showPagination" type="I"><unsigned/></field>
@@ -16,4 +18,10 @@
 		<field name="showPageLink" type="I"><unsigned/></field>
 		<field name="showAddToCart" type="I"><unsigned/></field>
 	</table>
+
+	<table name="btVividStoreProductListGroups">
+		<field name="bID" type="I"><unsigned /></field>
+		<field name="gID" type="I"><unsigned/></field>
+	</table>
+
 </schema>

--- a/blocks/vivid_product_list/form.php
+++ b/blocks/vivid_product_list/form.php
@@ -2,37 +2,69 @@
 <fieldset>
     <legend><?=t('Product Arrangement')?></legend>
     <?php
-        $productgroups = array("0"=>t("None"));
         foreach($grouplist as $productgroup){
             $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
-        } 
+        }
     ?>
     <div class="row">
         <div class="col-xs-12">
             <div class="form-group">
-                <?php echo $form->label('filter',t('List'));?>
-                <?php echo $form->select('filter',array('all'=>t("All products"),'page'=>t('Products associated with this page'),'page_children'=>t('Products associated with this page and child pages')),$filter);?>
+                <?php echo $form->label('filter',t('List Products'));?>
+                <?php echo $form->select('filter',array(
+                    'all'=>t("All"),
+                    'current'=>t('Under current page'),
+                    'current_children'=>t('Under current page and child pages'),
+                    'page'=>t('Under a specified page'),
+                    'page_children'=>t('Under a specified page and child pages')
+                ),$filter);?>
             </div>
+
+            <div class="form-group" id="pageselector">
+                <div class="form-group" <?= ($filter == 'page' || $filter == 'page_children' ? '' : 'style="display: none"'); ?> >
+                    <?php
+                    $ps = Core::make('helper/form/page_selector');
+                    echo $ps->selectPage('filterCID', ($filterCID > 0 ? $filterCID : false) ); ?>
+                </div>
+            </div>
+
         </div>
     </div>
 
     <div class="row">
-        <?php if($productgroups){?>
+        <?php if(!empty($productgroups)){?>
         <div class="col-xs-6">
             <div class="form-group">
-                <?php echo $form->label('gID',t('Filter by Group'));?>
-                <?php echo $form->select('gID',$productgroups,$gID);?>
+                <?php echo $form->label('gID',t('Filter by Groups'));?>
+
+                <div class="ccm-search-field-content ccm-search-field-content-select2">
+                    <select multiple="multiple" name="filtergroups[]" id="groups-select" class="existing-select2 select2-select" style="width: 100%">
+                        <?php foreach ($productgroups as $pgkey=>$pglabel) { ?>
+                            <option value="<?php echo $pgkey;?>" <?php echo (in_array($pgkey, $groupfilters) ? 'selected="selected"' : ''); ?>><?php echo $pglabel; ?></option>
+                        <?php } ?>
+                    </select>
+                </div>
             </div>
         </div>
+
         <?php } ?>
 
         <div class="col-xs-6">
+            <div class="form-group">
+                <?php echo $form->label('groupMatchAny',t('Matching'));?>
+                <?php echo $form->select('groupMatchAny',array('0'=>t("All groups listed"),'1'=>t('Any group listed')),$groupMatchAny);?>
+            </div>
+        </div>
+
+
+    </div>
+
+    <div class="row">
+        <div class="col-xs-12">
             <div class="form-group">
                 <?php echo $form->label('sortOrder',t('Sort Order'));?>
                 <?php echo $form->select('sortOrder',array('alpha'=>t("Alphabetical"),'date'=>t('Recently Added')),$sortOrder);?>
             </div>
         </div>
-
     </div>
 
 
@@ -107,3 +139,22 @@
     </div>
     
 </fieldset>
+
+
+<script>
+    $(document).ready(function(){
+        $('#groups-select').select2();
+
+        $('#filter').change(function(){
+            if ($(this).val() == 'page' || $(this).val() == 'page_children') {
+                $('#pageselector').show();
+            }  else {
+                $('#pageselector').hide();
+            }
+        });
+
+    });
+</script>
+
+
+

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -68,8 +68,7 @@ class Products extends DashboardPageController
         $this->set("actionType",t("Add")); 
         
         $grouplist = VividProductGroupList::getGroupList();            
-        $this->set("grouplist",$grouplist);   
-        $productgroups = array("0"=>t("None"));
+        $this->set("grouplist",$grouplist);
         foreach($grouplist as $productgroup){
             $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
         }     
@@ -100,13 +99,13 @@ class Products extends DashboardPageController
         $product = VividProduct::getByID($pID);
         $this->set('p',$product);
         $this->set("images",$product->getProductImages());
-        $this->set("groups",$product->getProductOptionGroups()); 
+        $this->set("groups",$product->getProductOptionGroups());
         $this->set('optItems',$product->getProductOptionItems());
         $this->set('pages', $product->getProductPages());
-        
+        $this->set('pgroups', $product->getProductGroupIDs());
+
         //populate "Groups" select box options
-        $grouplist = VividProductGroupList::getGroupList();         
-        $productgroups = array("0"=>t("None"));
+        $grouplist = VividProductGroupList::getGroupList();
         foreach($grouplist as $productgroup){
             $productgroups[$productgroup->getGroupID()] = $productgroup->getGroupName();
         }     

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -7,6 +7,7 @@ $groupViews = array('groups','groupadded','addgroup');
 $attributeViews = array('attributes','attributeadded','attributeremoved');
 $ps = Core::make('helper/form/page_selector');
 
+
 use \Config;
 use \Concrete\Package\VividStore\Src\VividStore\Groups\ProductGroup as VividProductGroup;
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
@@ -77,14 +78,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     </div>
                 </div>
                 <div class="row">
-                    <?php if($productgroups){?>
-                        <div class="col-xs-6">
-                            <div class="form-group">
-                                <?php echo $form->label('gID',t('Group'));?>
-                                <?php echo $form->select('gID',$productgroups,$p->getGroupID());?>
-                            </div>
-                        </div>
-                    <?php } ?>
                     <div class="col-xs-6">
                         <div class="form-group">
                             <?php echo $form->label("pFeatured", t("Featured Product"));?>
@@ -133,7 +126,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             <div class="col-sm-7 store-pane" id="product-categories">
                 <h4><?=t('Categorized under pages')?></h4>
 
-
                 <div class="form-group" id="page_pickers">
                     <div class="page_picker">
                         <?php echo $ps->selectPage('cID[]', $pages[0]['cID'] ?  $pages[0]['cID'] : false); ?>
@@ -145,12 +137,22 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         </div>
 
                     <?php } ?>
+                </div>
 
+                <h4><?=t('In product groups')?></h4>
+                <div class="ccm-search-field-content ccm-search-field-content-select2">
+                    <select multiple="multiple" name="pProductGroups[]" class="existing-select2 select2-select" style="width: 100%">
+                        <?php foreach ($productgroups as $pgkey=>$pglabel) { ?>
+                            <option value="<?php echo $pgkey;?>" <?php echo (in_array($pgkey, $pgroups) ? 'selected="selected"' : ''); ?>>  <?php echo $pglabel; ?></option>
+                        <?php } ?>
+                    </select>
                 </div>
 
 
                 <script>
                     $(document).ready(function(){
+                        $('.existing-select2').select2();
+
                         Concrete.event.bind('ConcreteSitemap', function(e, instance) {
                             var instance = instance;
                             Concrete.event.bind('SitemapSelectPage', function(e, data) {
@@ -167,7 +169,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         });
 
                     });
-
                 </script>
 
                 <style>
@@ -694,7 +695,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             <th><a><?=t('Quantity')?></a></th>
             <th><a><?=t('Price')?></a></th>
             <th><a><?=t('Featured')?></a></th>
-            <th><a><?=t('Group')?></a></th>
+            <th><a><?=t('Groups')?></a></th>
             <th><a><?=t('Actions')?></a></th>
             </thead>
             <tbody>
@@ -716,13 +717,14 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             }
                             ?>
                         </td>
-                        <td><?php $group = VividProductGroup::getByID($p->getGroupID());
-                            if (is_object($group)) { ?>
-                                <span class="label label-primary">
-                            <?= $group->getGroupName() ?>
-                        </span>
-                            <?php } else { ?>
-                                <span class="label label-default"><?= t("None") ?></span>
+                        <td>
+                            <?php $productgroups = $p->getProductGroups();
+                            foreach($productgroups as $pg) { ?>
+                                <span class="label label-primary"><?= $pg; ?></span>
+                             <?php } ?>
+
+                            <?php if (empty($productgroups)) { ?>
+                                <em><?= t('None');?></em>
                             <?php } ?>
                         </td>
                         <td>

--- a/src/VividStore/Product/Product.php
+++ b/src/VividStore/Product/Product.php
@@ -71,6 +71,15 @@ class Product extends Object
                     $db->Execute("INSERT INTO VividStoreProductUserGroups (pID,gID) VALUES (?,?)",$vals);
                 }
             }
+
+            //update product groups
+            $db->Execute('DELETE FROM VividStoreProductGroups WHERE pID = ?', $data['pID']);
+            if (!empty($data['pProductGroups'])) {
+                foreach($data['pProductGroups'] as $gID){
+                    $vals = array($pID,$gID);
+                    $db->Execute("INSERT INTO VividStoreProductGroups (pID,gID) VALUES (?,?)",$vals);
+                }
+            }
             
             //update option groups
             $db->Execute('DELETE FROM VividStoreProductOptionGroups WHERE pID = ?', $data['pID']);
@@ -113,13 +122,22 @@ class Product extends Object
                 }
             }
 
-            //update user groups
+            //insert user groups
             if (!empty($data['pUserGroups'])) {
                 foreach($data['pUserGroups'] as $gID){
                     $vals = array($pID,$gID);
                     $db->Execute("INSERT INTO VividStoreProductUserGroups (pID,gID) VALUES (?,?)",$vals);
                 }
             }
+
+            //insert product groups
+            if (!empty($data['pProductGroups'])) {
+                foreach($data['pProductGroups'] as $gID){
+                    $vals = array($pID,$gID);
+                    $db->Execute("INSERT INTO VividStoreProductGroups (pID,gID) VALUES (?,?)",$vals);
+                }
+            }
+
             
             //add option groups
             $count = count($data['pogSort']);
@@ -368,6 +386,30 @@ class Product extends Object
         $optionItem = $db->GetRow("SELECT * FROM VividStoreProductOptionItems WHERE poiID=?",$id);
         return $optionItem['poiName'];
     }
+
+
+    public function getProductGroupIDs()
+    {
+        $db = Database::get();
+        $groups = $db->GetAll("SELECT gID FROM VividStoreProductGroups WHERE pID=?",$this->pID);
+        $values = array();
+        foreach($groups as $g) {
+            $values[] = $g['gID'];
+        }
+        return $values;
+    }
+
+    public function getProductGroups()
+    {
+        $db = Database::get();
+        $groups = $db->GetAll("SELECT pg.gID, groupName  FROM VividStoreProductGroups pg INNER JOIN VividStoreGroups g on pg.gID = g.gID WHERE pID=?",$this->pID);
+        $values = array();
+        foreach($groups as $g) {
+            $values[$g['gID']] = $g['groupName'];
+        }
+        return $values;
+    }
+
 
     public function setAttribute($ak, $value)
     {

--- a/src/VividStore/Product/ProductList.php
+++ b/src/VividStore/Product/ProductList.php
@@ -12,7 +12,8 @@ defined('C5_EXECUTE') or die(_("Access Denied."));
 class ProductList extends AttributedItemList
 {
     
-    protected $gID = 0;
+    protected $gIDs = array();
+    protected $groupMatchAny = false;
     protected $sortBy = "alpha";
     protected $featured = "all";
     protected $activeOnly = true;
@@ -20,9 +21,15 @@ class ProductList extends AttributedItemList
     
     public function setGroupID($gID)
     {
-        $this->gID = $gID;
+        $this->gIDs = array($gID);
     }
-    
+
+    public function setGroupIDs($groupIDs)
+    {
+        $this->gIDs = array_merge($this->gIDs, $groupIDs);
+    }
+
+
     public function setSortBy($sort)
     {
         $this->sortBy = $sort;
@@ -34,6 +41,10 @@ class ProductList extends AttributedItemList
 
     public function setCIDs($cIDs) {
         $this->cIDs = array_merge($this->cIDs, array_values($cIDs));
+    }
+
+    public function setGroupMatchAny($match) {
+        $this->groupMatchAny = (bool)$match;
     }
     
     public function setFeatureType($type)
@@ -65,9 +76,24 @@ class ProductList extends AttributedItemList
     {
         $paramcount = 0;
 
-        if(isset($this->gID) && ($this->gID > 0)){
-            $query->where('gID = ?')->setParameter($paramcount++,$this->gID);
+        if(!empty($this->gIDs)) {
+            $validgids = array();
+
+            foreach($this->gIDs as $gID) {
+                if ($gID > 0) {
+                    $validgids[] = $gID;
+                }
+            }
+
+            if (!empty($validgids)) {
+                $query->innerJoin('p', 'VividStoreProductGroups', 'g', 'p.pID = g.pID and g.gID in (' . implode(',', $validgids) . ')');
+
+                if (!$this->groupMatchAny) {
+                    $query->having('count(g.gID) = '  . count($validgids));
+                }
+            }
         }
+
         switch ($this->sortBy){
             case "alpha":
                 $query->orderBy('pName','ASC');
@@ -90,9 +116,9 @@ class ProductList extends AttributedItemList
 
         if (is_array($this->cIDs) && !empty($this->cIDs)) {
             $query->innerJoin('p', 'VividStoreProductLocations', 'l', 'p.pID = l.pID and l.cID in (' .  implode(',',$this->cIDs). ')');
-            $query->groupBy('p.pID');
         }
 
+        $query->groupBy('p.pID');
 
         if ($this->search) {
             $query->andWhere('pName like ?')->setParameter($paramcount++,'%'. $this->search. '%');


### PR DESCRIPTION
Adds:
- ability to add multiple product groups to products
- ability to filter product lists to one or more groups (and select any/all group matching)
- ability to select another page to select products from
  (this finished up what I think is needed for product filtering)

Doesn't include in upgrade scripts something to convert the existing product group over to new table structure. This wouldn't be a big deal to write, but wasn't sure if it would be necessary.

Addresses #12 
