### PR TITLE
Remove empty statement

### DIFF
--- a/blocks/vivid_product_list/view.php
+++ b/blocks/vivid_product_list/view.php
@@ -17,7 +17,7 @@ if($products){
                     if(is_object($imgObj)){
                         $thumb = $ih->getThumbnail($imgObj,400,280,true);?>
                         <div class="product-list-thumbnail">
-                            <?php if($showQuickViewLink || empty($showQuickViewLink)){ ?>
+                            <?php if($showQuickViewLink){ ?>
                             <a class="product-quick-view" href="javascript:vividStore.productModal(<?=$product->getProductID()?>);">
                                 <?=t("Quick View")?>
                             </a>


### PR DESCRIPTION
Otherwise the quick link is always displayed event when it is not checked.
