### PR TITLE
Max/min values for payment methods

### DIFF
--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -130,9 +130,20 @@ class Checkout extends PageController
                 vividStore.loadViaHash();
             </script>
         ");
-        $this->set("enabledPaymentMethods",PaymentMethod::getEnabledMethods());
-        
-        
+
+        $enabledMethods = PaymentMethod::getEnabledMethods();
+
+        $availableMethods = array();
+
+        foreach($enabledMethods as $em) {
+            $emmc = $em->getMethodController();
+
+            if ($totals['total'] >= $emmc->getPaymentMinimum() && $totals['total'] <=  $emmc->getPaymentMaximum()) {
+                $availableMethods[] = $em;
+            }
+        }
+
+        $this->set("enabledPaymentMethods",$availableMethods);
     }
     
     public function failed()

--- a/elements/invoice/dashboard_form.php
+++ b/elements/invoice/dashboard_form.php
@@ -1,3 +1,15 @@
 <?php 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 extract($vars);
+?>
+
+<div class="form-group">
+    <label><?=t("Minimum Order Value")?></label>
+<input type="text" name="invoiceMinimum" value="<?=$invoiceMinimum?>" class="form-control">
+</div>
+
+<div class="form-group">
+    <label><?=t("Maximum Order Value")?></label>
+    <input type="text" name="invoiceMaximum" value="<?=$invoiceMaximum?>" class="form-control">
+</div>
+

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -266,12 +266,17 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                             $pm->renderCheckoutForm();
                             echo "</div>";
                         }
-                    }//if payment methods
-                ?>              
+                    } else {  //if payment methods
+                ?>
+                <p class="alert alert-warning"><?= t('There are currently no payment methods available to process your order.'); ?></p>
+                <?php } ?>
                 
                 <div class="clearfix checkout-form-group-buttons">
                     <a href="javascript:;" class="btn btn-default btn-previous-pane"><?=t("Previous")?></a>
+
+                    <?php if($enabledPaymentMethods){ ?>
                     <input type="submit" class="btn btn-default btn-complete-order" value="<?=t("Complete Order")?>">
+                    <?php } ?>
                 </div>
                 
             </div>

--- a/src/VividStore/Discount/DiscountRule.php
+++ b/src/VividStore/Discount/DiscountRule.php
@@ -161,7 +161,6 @@ class DiscountRule extends Object
                 $data['drTrigger'],
                 $data['drSingleUseCodes'],
                 $data['drExclusive'],
-                $data['drExclusive'],
                 $data['drCurrency'],
                 $data['drValidFrom_dt'],
                 $data['drValidTo_dt'],

--- a/src/VividStore/Payment/Method.php
+++ b/src/VividStore/Payment/Method.php
@@ -170,5 +170,13 @@ class Method extends Controller
         $class = $this->getMethodController();
         return $class->submitPayment();
     }
+
+    public function getPaymentMinimum() {
+        return 0;
+    }
+
+    public function getPaymentMaximum() {
+        return 1000000000; // raises pinky
+    }
       
 }

--- a/src/VividStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
+++ b/src/VividStore/Payment/Methods/Invoice/InvoicePaymentMethod.php
@@ -3,6 +3,7 @@ namespace Concrete\Package\VividStore\Src\VividStore\Payment\Methods\Invoice;
 
 use \Concrete\Package\VividStore\Src\VividStore\Payment\Method as PaymentMethod;
 use Core;
+use Config;
 
 defined('C5_EXECUTE') or die(_("Access Denied."));
 class InvoicePaymentMethod extends PaymentMethod
@@ -10,11 +11,14 @@ class InvoicePaymentMethod extends PaymentMethod
     public function dashboardForm()
     {
         $this->set('form',Core::make("helper/form"));
+        $this->set('invoiceMinimum',Config::get('vividstore.invoiceMinimum'));
+        $this->set('invoiceMaximum',Config::get('vividstore.invoiceMaximum'));
     }
     
     public function save($data)
     {
-        //nothing to save really.
+        Config::save('vividstore.invoiceMinimum',$data['invoiceMinimum']);
+        Config::save('vividstore.invoiceMaximum',$data['invoiceMaximum']);
     }
     public function validate($args,$e)
     {
@@ -36,7 +40,29 @@ class InvoicePaymentMethod extends PaymentMethod
         
     }
 
-    
+    public function getPaymentMinimum() {
+        $defaultMin  = 0;
+
+        $minconfig = trim(Config::get('vividstore.invoiceMinimum'));
+
+        if ($minconfig == '') {
+            return $defaultMin;
+        } else {
+            return max($minconfig, $defaultMin);
+        }
+    }
+
+    public function getPaymentMaximum() {
+        $defaultMax  = 1000000000;
+
+        $maxconfig = trim(Config::get('vividstore.invoiceMaximum'));
+        if ($maxconfig == '') {
+            return $defaultMax;
+        } else {
+            return min($maxconfig, $defaultMax);
+        }
+    }
+
 }
 
 return __NAMESPACE__;

--- a/src/VividStore/Payment/Methods/PaypalStandard/PaypalStandardPaymentMethod.php
+++ b/src/VividStore/Payment/Methods/PaypalStandard/PaypalStandardPaymentMethod.php
@@ -164,5 +164,10 @@ class PaypalStandardPaymentMethod extends PaymentMethod
         }
     }
 
-    
+
+    public function getPaymentMinimum() {
+        return 0.03;
+    }
+
+
 }


### PR DESCRIPTION
- Introduces way to set minimum and maximum values for payment methods, via optional functions.
- Solves the issue of free orders being able to be processed by methods like Paypal
- Invoice payment method can have a min and max set
- Adds in warning message to checkout if no payment method is available
- Quick fix to discount saving bug

Addresses #1 
