### PR TITLE
Prevent tax dashboard page from throwing an error when taxRate not an object

### DIFF
--- a/src/VividStore/Tax/TaxClass.php
+++ b/src/VividStore/Tax/TaxClass.php
@@ -61,7 +61,12 @@ class TaxClass
         $taxRates =  explode(',',$this->taxClassRates); 
         $taxes = array();
         foreach($taxRates as $tr){
-            $taxes[] = TaxRate::getByID($tr);
+            if ($tr) {
+                $taxrate = TaxRate::getByID($tr);
+                if ($taxrate) {
+                    $taxes[] = $taxrate;
+                }
+            }
         }
         return $taxes;
     }


### PR DESCRIPTION
Fix to TaxClass returning an array of rates with an empty value
