### PR TITLE
page not found when pretty url not enabled

### DIFF
--- a/js/vivid-store.js
+++ b/js/vivid-store.js
@@ -65,7 +65,7 @@ exitModal: function(){
                     var res = jQuery.parseJSON(data);
 
                     if (res.product.pAutoCheckout == '1') {
-                        window.location.href = CCM_APPLICATION_URL + "/checkout";
+                        window.location.href = CHECKOUTURL;
                         return false;
                     }
 


### PR DESCRIPTION
When pretty url is not enabled the checkout was not found as the index.php was missing. Since the block has this CHECKOUTURL variable set with the proper value, might as well use it.
