### PR TITLE
Error when already registered but not logged in

### DIFF
--- a/src/VividStore/Orders/Order.php
+++ b/src/VividStore/Orders/Order.php
@@ -237,7 +237,7 @@ class Order extends Object
         }
 
 
-        if (!$customer->isGuest() || $createlogin) {
+        if (!$customer->isGuest() && $createlogin) {
             $user = $customer->getUserInfo()->getUserObject();
 
             //add user to Store Customers group


### PR DESCRIPTION
When buying a membership requiring registration and using an existing email while not logged in, the checkout would fail as customer ui would be null and so running $user = $customer->getUserInfo()->getUserObject(); would throw an "not an object" error.

What's more, the || instead of the && doesn't seem logical.
