### PR TITLE
Checkout panel scrolling and more useful class usage

### DIFF
--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -42,8 +42,6 @@ class Controller extends BlockController
     public function registerViewAssets()
     {
         
-        $pkg = Package::getByHandle('vivid_store');
-        $packagePath = $pkg->getRelativePath();
         $this->addHeaderItem("
             <script type=\"text/javascript\">
                 var PRODUCTMODAL = '".View::url('/productmodal')."';

--- a/controller.php
+++ b/controller.php
@@ -61,7 +61,7 @@ class Controller extends Package
 
     public function install()
     {
-        $pkg = parent::install();
+        parent::install();
         $this->installStore();
     }
 

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -103,9 +103,6 @@ class Checkout extends PageController
         $this->set('subtotal',$totals['subTotal']);
         $this->set('taxes',$totals['taxes']);
 
-        $taxBased = Config::get('vividstore.taxBased');
-        $taxlabel = Config::get('vividstore.taxName');
-        
         $this->set('taxtotal',$totals['taxTotal']);
 
         $this->set('shippingtotal',$totals['shippingTotal']);
@@ -120,7 +117,6 @@ class Checkout extends PageController
             </script>
         ");
 
-        $packagePath = $pkg->getRelativePath();
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
         $this->addFooterItem("
@@ -177,9 +173,8 @@ class Checkout extends PageController
                 $pmsess = Session::get('paymentMethod');
                 $pmsess[$pm->getPaymentMethodID()] = $data['payment-method'];
                 Session::set('paymentMethod',$pmsess);
-                $pesess = Session::get('paymentErrors');
-                $pesess = $payment['errorMessage'];
-                Session::set('paymentErrors',$pesess);
+                $errors = $payment['errorMessage'];
+                Session::set('paymentErrors',$errors);
                 $this->redirect("/checkout/failed#payment");
             } else {
                 $transactionReference = $payment['transactionReference'];

--- a/controllers/single_page/dashboard/store/products/attributes.php
+++ b/controllers/single_page/dashboard/store/products/attributes.php
@@ -83,15 +83,7 @@ class Attributes extends DashboardPageController
             $this->set('error', $e);
         } else {
             $type = AttributeType::getByID($this->post('atID'));
-            $args = array(
-                'akHandle' => $this->post('akHandle'),
-                'akName' => $this->post('akName'),
-                'akIsSearchable' => $this->post('akIsSearchable'),
-                'akIsSearchableIndexed' => $this->post('akIsSearchableIndexed'),
-                'akIsAutoCreated' => 0,
-                'akIsEditable' => 1
-            );
-            $ak = StoreProductKey::add($type, $this->post());
+            StoreProductKey::add($type, $this->post());
             $this->redirect('/dashboard/store/products/attributes/', 'success');
         }
     }
@@ -113,15 +105,6 @@ class Attributes extends DashboardPageController
             if ($e->has()) {
                 $this->set('error', $e);
             } else {
-                $type = AttributeType::getByID($this->post('atID'));
-                $args = array(
-                    'akHandle' => $this->post('akHandle'),
-                    'akName' => $this->post('akName'),
-                    'akIsSearchable' => $this->post('akIsSearchable'),
-                    'akIsSearchableIndexed' => $this->post('akIsSearchableIndexed'),
-                    'akIsAutoCreated' => 0,
-                    'akIsEditable' => 1
-                );
                 $key->update($this->post());
                 $this->redirect('/dashboard/store/products/attributes', 'updated');
             }

--- a/controllers/single_page/dashboard/store/reports/sales.php
+++ b/controllers/single_page/dashboard/store/reports/sales.php
@@ -16,7 +16,6 @@ class Sales extends DashboardPageController
         $sr = new StoreSalesReport();
         $this->set('sr',$sr);
         $pkg = Package::getByHandle('vivid_store');
-        $packagePath = $pkg->getRelativePath();
         $this->requireAsset('chartist');
         $today = date('Y-m-d');
         $thirtyDaysAgo = date('Y-m-d', strtotime('-30 days'));
@@ -47,6 +46,7 @@ class Sales extends DashboardPageController
         $this->requireAsset('css', 'vividStoreDashboard');
      
     }
+    //TODO
     public function export()
     {
         $from = $this->get('fromDate');

--- a/controllers/single_page/dashboard/store/settings/shipping/clerk.php
+++ b/controllers/single_page/dashboard/store/settings/shipping/clerk.php
@@ -39,19 +39,19 @@ class Clerk extends DashboardPageController
     public function save()
     {
         $errors = $this->validate($this->post());
-        $addOrUpdate = $this->post('id') > 0 ? 'update' : 'add';
         $this->error = null; //clear errors
         $this->error = $errors;
         if(!$errors->has())
         {
-            StoreClerkPackage::addOrUpdate($this->post(),$addOrUpdate);
-            if($addOrUpdate=='add'){
+            if($this->post('id') > 0){
+                StoreClerkPackage::add($this->post());
                 $this->redirect('/dashboard/store/settings/shipping/clerk/success');
             } else {
+                StoreClerkPackage::getByID($this->post('id'))->update($this->post());
                 $this->redirect('/dashboard/store/settings/shipping/clerk/updated');
             }
         }
-        if($addOrUpdate=='add'){
+        if($this->post('id') > 0){
             $this->add();
         } else {
             $this->edit($this->post('id'));

--- a/css/vivid-store.css
+++ b/css/vivid-store.css
@@ -32,7 +32,7 @@
         .product-modal-thumb { float: left; width: 40%; }
             .product-modal-thumb img { max-width: 100%; height: auto; }
         .product-modal-info-shell { float: left; width: 50%; margin-left: 10%; position: relative;}
-            .product-modal-exit { position: absolute; font-size: 18px; right: 0px; top: 0px; color: #ccc; cursor: pointer; }
+            .product-modal-exit { position: absolute; font-size: 18px; right: 0; top: 0; color: #ccc; cursor: pointer; }
             .cart-modal .product-modal-exit { right: 15px; top: 5px; }
             .product-modal-exit:hover { color: #888; text-decoration: none; }
             .product-modal-title { display: block; font-size: 22px; padding: 10px 0 0; }
@@ -78,7 +78,7 @@
         .cart-page-cart-links .btn-cart-page-checkout {  }
 
 @media (min-width: 768px) {
-    .cart-page-cart-list li.cart-page-cart-list-item { padding: 15px 0; border: none; border-bottom: 2px solid rgba(0,0,0,0.1); background: none; border-radius: none; margin-bottom: 0; }
+    .cart-page-cart-list li.cart-page-cart-list-item { padding: 15px 0; border: none; border-bottom: 2px solid rgba(0,0,0,0.1); background: none; border-radius: 0; margin-bottom: 0; }
     .cart-page-cart-list li.cart-page-cart-list-item.striped { background: rgba(0,0,0,0.01); }
      .cart-page-cart-list li.cart-page-cart-list-item .cart-list-item-links a { padding: 5px 15px; }
 }

--- a/css/vivid-store.css
+++ b/css/vivid-store.css
@@ -111,10 +111,12 @@
         .checkout-form-group h2 { padding: 8px 15px; background: #f8f8f8; font-size: 16px !important; margin: 0 !important; }
         .checkout-form-group-body { padding: 20px 0; display: none; }
         .checkout-form-group-summary { padding: 20px 0; display: none; }
-        #checkout-form-group-billing .checkout-form-group-body,
+        .checkout-form-group-complete .checkout-form-group-summary  { display: block; }
         #checkout-form-group-signin .checkout-form-group-body { display: block; }
         .checkout-form-group-summary .vivid-store-col-2 { padding-top: 0; padding-bottom: 0;}
         .checkout-form-group-buttons { text-align: right; padding: 0 15px;}
+
+.active-form-group .checkout-form-group-body { display: block; }
     
 @media (min-width: 768px) {
     .checkout-form-shell { float: left; width: 70%; }   

--- a/db.xml
+++ b/db.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0"?>
 <schema version="0.3">
-	<table name="VividStoreOrders">
-        <field name="oID" type="I"><key /><unsigned /><autoincrement/></field>
-        <field name="cID" type="I"></field>
-        <field name="oDate" type="T"></field>
-        <field name="oStatus" type="C" size="50"></field>
-        <field name="pmName" type="C" size="50"></field>
-        <field name="transactionReference" type="C" size="255"></field>
-        <field name="smName" type="C" size="50"></field>
-        <field name="oShippingTotal" type="C" size="10"></field>
-        <field name="oTax" type="C" size="255"></field>
-        <field name="oTaxIncluded" type="C" size="255"></field>
-        <field name="oTaxName" type="C" size="255"></field>
-        <field name="oTotal" type="C" size="10"></field>
-    </table>
-    <table name="VividStoreOrderDiscounts">
+	<table name="VividStoreOrderDiscounts">
         <field name="oID" type="I"><unsigned /></field>
         <field name="odName" type="C" size="255"></field>
         <field name="odDisplay" type="C" size="255"></field>

--- a/js/vivid-store.js
+++ b/js/vivid-store.js
@@ -63,10 +63,11 @@ exitModal: function(){
 
     //Add Item to Cart
     addToCart: function(pID, modal){
+        var form;
         if(modal==true){
-            var form = $('#form-add-to-cart-modal-'+pID);
+            form = $('#form-add-to-cart-modal-'+pID);
         } else {
-            var form = $('#form-add-to-cart-'+pID);
+            form = $('#form-add-to-cart-'+pID);
         }
         var qty = $(form).find('.product-qty').val();
         if(qty > 0){
@@ -235,11 +236,11 @@ exitModal: function(){
 
     updateBillingStates: function(load){
         var countryCode = $("#checkout-billing-country").val();
-
+        var selectedState;
         if (load){
-            var selectedState = $("#checkout-saved-billing-state").val();
+            selectedState = $("#checkout-saved-billing-state").val();
         } else {
-            var selectedState = '';
+            selectedState = '';
         }
        
         $.ajax({
@@ -256,11 +257,11 @@ exitModal: function(){
     
     updateShippingStates: function(load){
         var countryCode = $("#checkout-shipping-country").val();
-
+        var selectedState;
         if (load){
-            var selectedState = $("#checkout-saved-shipping-state").val();
+            selectedState = $("#checkout-saved-shipping-state").val();
         } else {
-            var selectedState = '';
+            selectedState = '';
         }
 
         $.ajax({

--- a/js/vivid-store.js
+++ b/js/vivid-store.js
@@ -228,8 +228,14 @@ exitModal: function(){
         var hash = window.location.hash;
         hash = hash.replace('#','');
         if(hash != ""){
-            $(".checkout-form-group .checkout-form-group-body").hide();
-            $("#checkout-form-group-"+hash+" .checkout-form-group-body").show();
+            //$(".checkout-form-group .checkout-form-group-body").hide();
+            $(".active-form-group").removeClass('active-form-group');
+            var pane = $("#checkout-form-group-"+hash);
+            pane.addClass('active-form-group');
+
+            $('html, body').animate({
+                scrollTop: pane.offset().top
+            });
         }
     },
     //loadViaHash();
@@ -273,13 +279,21 @@ exitModal: function(){
            } 
         });
     },
-    
-    
+
+
     nextPane: function(obj){
-       if($(obj)[0].checkValidity()){
-           $(obj).closest(".checkout-form-group").find('.checkout-form-group-body').hide().parent().next().find(".checkout-form-group-body").show();
-           $(obj).closest(".checkout-form-group").find('.checkout-form-group-summary').show();
-       } else { alert("not valid"); }
+        if($(obj)[0].checkValidity()){
+            var pane = $(obj).closest(".checkout-form-group").find('.checkout-form-group-body').parent().next();
+            $('.active-form-group').removeClass('active-form-group');
+            pane.addClass('active-form-group');
+            $(obj).closest(".checkout-form-group").addClass('checkout-form-group-complete');
+
+            $('html, body').animate({
+                scrollTop: pane.offset().top
+            });
+
+            pane.find('input:first-child').focus();
+        }
     },
     
     showShippingMethods: function(){
@@ -469,9 +483,16 @@ $("#checkout-form-group-billing").submit(function(e){
         }
     });
     $(".btn-previous-pane").click(function(){
-       //hide the body of the current pane, go to the next pane, show that body.
-       $(this).closest(".checkout-form-group").find('.checkout-form-group-body').hide().parent().prev().find(".checkout-form-group-body").show();        
-       $(this).closest(".checkout-form-group").prev().find(".checkout-form-group-summary").hide();
+        //hide the body of the current pane, go to the next pane, show that body.
+        var pane = $(this).closest(".checkout-form-group").find('.checkout-form-group-body').parent().prev();
+        $('.active-form-group').removeClass('active-form-group');
+        pane.addClass('active-form-group');
+
+        $('html, body').animate({
+            scrollTop: pane.parent().offset().top
+        });
+
+        $(this).closest(".checkout-form-group").prev().removeClass("checkout-form-group-complete");
     });
     $("#ckbx-copy-billing").change(function(){
        if($(this).is(":checked")){

--- a/single_pages/checkout.php
+++ b/single_pages/checkout.php
@@ -12,7 +12,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
         <?php
             if ($customer->isGuest() && ($requiresLogin || $guestCheckout == 'off' || ($guestCheckout == 'option' && $_GET['guest'] != '1'))){
         ?>
-        <div class="checkout-form-group" id="checkout-form-group-signin">
+        <div class="checkout-form-group active-form-group" id="checkout-form-group-signin">
 
             <?php 
                 if ($guestCheckout == 'option' && !$requiresLogin) {
@@ -43,7 +43,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
             
         </div>
         <?php } else {   ?>
-        <form class="checkout-form-group" id="checkout-form-group-billing" action="">
+        <form class="checkout-form-group active-form-group" id="checkout-form-group-billing" action="">
             
             <h2><?=t("Billing Address")?></h2>
             <div class="checkout-form-group-body col-container clearfix">

--- a/single_pages/dashboard/store/discounts.php
+++ b/single_pages/dashboard/store/discounts.php
@@ -94,9 +94,15 @@ $currencySymbol = Config::get('vividstore.symbol');
 
 
                             </td>
-                            <td><span class="label label-<?= ($d->drEnabled ? 'success">' . t('Enabled') : 'danger">' . t('Disabled')); ?></span></td>
                             <td>
-                                <p><a class="btn btn-default" href="<?php echo View::url('/dashboard/store/discounts/edit/', $d->drID)?>"><i  class="fa fa-pencil"></i></a></p>
+                                <?php if($d->drEnabled){ ?>
+                                    <span class="label label-danger"><?=t('Disabled')?></span>
+                                <?php } else { ?>
+                                    <span class="label label-success"><?=t('Enabled')?></span>
+                                <?php } ?>
+                            </td>
+                            <td>
+                                <p><a class="btn btn-default" href="<?php echo View::url('/dashboard/store/discounts/edit/', $d->drID)?>"><i class="fa fa-pencil"></i></a></p>
                                 <?php
                                 if ($d->drTrigger == 'code') {
                                     echo '<p>' . '<a class="btn btn-default btn-sm" href="'.View::url('/dashboard/store/discounts/codes/', $d->drID).'">'.t('Manage Codes').'</a></p>';
@@ -358,10 +364,10 @@ $currencySymbol = Config::get('vividstore.symbol');
 
 <p class="alert alert-info">
     <?php if ($d->drSingleUseCodes) { ?>
-    <?= t('Single Use Codes'); ?></p>
-<?php } else { ?>
-    <?= t('Codes can be repeatedly used'); ?>
-<?php } ?>
+        <?= t('Single Use Codes'); ?></p>
+    <?php } else { ?>
+        <?= t('Codes can be repeatedly used'); ?>
+    <?php } ?>
 </p>
 
 

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -205,7 +205,7 @@ class Cart
         return array('exists'=>$sameproduct,'cartItemKey'=>$k);
     }
 
-    public function update($data)
+    public static function update($data)
     {
         $instanceID = $data['instance'];
         $qty = $data['pQty'];
@@ -232,7 +232,7 @@ class Cart
         return array('added' => $added);
     }
 
-    public function remove($instanceID)
+    public static function remove($instanceID)
     {
         $cart = self::getCart();
         unset($cart[$instanceID]);
@@ -248,7 +248,7 @@ class Cart
         self::$cart = null;
     }
     
-    public function getTotalItemsInCart(){
+    public static function getTotalItemsInCart(){
         $total = 0;
         if(self::getCart()){
             foreach(self::getCart() as $item){
@@ -309,7 +309,7 @@ class Cart
 
 
     // determines if a cart requires a customer to be logged in
-    public function requiresLogin() {
+    public static function requiresLogin() {
         if(self::getCart()){
             foreach(self::getCart() as $item) {
                 $product = StoreProduct::getByID($item['product']['pID']);

--- a/src/VividStore/Group/GroupList.php
+++ b/src/VividStore/Group/GroupList.php
@@ -6,7 +6,7 @@ use Database;
 class GroupList
 {
     
-    public function getGroupList()
+    public static function getGroupList()
     {
         $queryBuilder = Database::get()->getEntityManager()->createQueryBuilder();
         return $queryBuilder->select('g')

--- a/src/VividStore/Order/Order.php
+++ b/src/VividStore/Order/Order.php
@@ -1,7 +1,6 @@
 <?php 
 namespace Concrete\Package\VividStore\Src\VividStore\Order;
 
-use Concrete\Core\Foundation\Object as Object;
 use Database;
 use User;
 use Core;
@@ -23,7 +22,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Shipping\ShippingMethod as Store
 use \Concrete\Package\VividStore\Src\VividStore\Order\OrderEvent as StoreOrderEvent;
 use \Concrete\Package\VividStore\Src\VividStore\Order\OrderStatus\OrderStatusHistory as StoreOrderStatusHistory;
 use \Concrete\Package\VividStore\Src\VividStore\Order\OrderStatus\OrderStatus as StoreOrderStatus;
-use \Concrete\Package\VividStore\Src\VividStore\Discount\DiscountCode as StoreDiscountCode;
 use \Concrete\Package\VividStore\Src\VividStore\Payment\Method as StorePaymentMethod;
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Calculator as StoreCalculator;
 
@@ -55,12 +53,15 @@ class Order
    
     /** @Column(type="decimal", precision=10, scale=2) **/
     protected $oShippingTotal;
-    
-    /** @Column(type="decimal", precision=10, scale=2) **/
+
+    /** @Column(type="text", nullable=true) **/
     protected $oTax;
     
-    /** @Column(type="decimal", precision=10, scale=2, nullable=true) **/
+    /** @Column(type="text", nullable=true) **/
     protected $oTaxIncluded;
+
+    /** @Column(type="text", nullable=true) **/
+    protected $oTaxName;
     
     /** @Column(type="decimal", precision=10, scale=2) **/
     protected $oTotal;
@@ -75,6 +76,7 @@ class Order
     public function setShippingTotal($shippingTotal){ $this->oShippingTotal = $shippingTotal; }
     public function setTaxTotals($taxTotal){ $this->oTax = $taxTotal; }
     public function setTaxIncluded($taxIncluded){ $this->oTaxIncluded = $taxIncluded; }
+    public function setTaxLabels($taxLabels){ $this->oTaxName = $taxLabels; }
     public function setOrderTotal($total){ $this->oTotal = $total; }
     public function setTransactionReference($transactionReference){ $this->transactionReference = $transactionReference; }
     public function saveTransactionReference($transactionReference)
@@ -159,6 +161,7 @@ class Order
      * @param StorePaymentMethod $pm
      * @param string $transactionReference
      * @param boolean $status
+     * @return Order
      */
     public function add($data,$pm,$transactionReference='',$status=null)
     {
@@ -177,7 +180,9 @@ class Order
         $order->setPaymentMethodName($pmName);
         $order->setShippingMethodName($smName);
         $order->setShippingTotal($shippingTotal);
-        $order->setTaxTotals($taxes);
+        $order->setTaxTotals($taxes['taxTotals']);
+        $order->setTaxIncluded($taxes['taxIncludedTotal']);
+        $order->setTaxLabels($taxes['taxLabels']);
         $order->setOrderTotal($total);
         $order->save();
 

--- a/src/VividStore/Order/OrderList.php
+++ b/src/VividStore/Order/OrderList.php
@@ -7,7 +7,6 @@ use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
 
 use Concrete\Package\VividStore\Src\VividStore\Order\Order as StoreOrder;
-use Concrete\Package\VividStore\Src\VividStore\Order\OrderItem as StoreOrderItem;
 
 class OrderList  extends AttributedItemList
 {

--- a/src/VividStore/Payment/Method.php
+++ b/src/VividStore/Payment/Method.php
@@ -117,8 +117,8 @@ class Method extends Controller
         $db = Database::get();
         $db->Execute("DELETE FROM VividStorePaymentMethods WHERE pmID=?",$this->pmID);
     }
-      
-    public function getMethods($enabled=false)
+
+    public static function getMethods($enabled=false)
     {
         $db = Database::get();
         if($enabled==true){

--- a/src/VividStore/Report/SalesReport.php
+++ b/src/VividStore/Report/SalesReport.php
@@ -54,14 +54,14 @@ class SalesReport extends StoreOrderList
         $thirtyDaysAgo = date('Y-m-d', strtotime('-30 days'));
         return self::getTotalsByRange($thirtyDaysAgo,$today,0);
     }
-    public function getYearToDate()
+    public static function getYearToDate()
     {
         $today = date('Y-m-d');
         $jan1 = new \DateTime(date("Y")."-01-01");
         $jan1 = $jan1->format("Y-m-d");
         return self::getTotalsByRange($jan1,$today,0);
     }
-    public function getByMonth($date)
+    public static function getByMonth($date)
     {
         $from = date('Y-m-01', strtotime($date));
         $to = date('Y-m-t', strtotime($date));

--- a/src/VividStore/Shipping/Clerk/ClerkPackage.php
+++ b/src/VividStore/Shipping/Clerk/ClerkPackage.php
@@ -135,14 +135,20 @@ class ClerkPackage implements \DVDoug\BoxPacker\Box
         $em = $db->getEntityManager();
         return $em->find('Concrete\Package\VividStore\Src\VividStore\Shipping\Clerk\ClerkPackage', $id);
     }
-    
-    public function addOrUpdate($data,$addOrUpdate)
+
+    public static function add($data)
     {
-        if($addOrUpdate=='update'){
-            $package = self::getByID($data['id']);
-        } elseif($addOrUpdate=='add') {
-            $package = new self();
-        }
+        $package = new ClerkPackage();
+        return self::addOrUpdate($data,$package);
+    }
+
+    public function update($data)
+    {
+        return $this->addOrUpdate($data,$this);
+    }
+    
+    public function addOrUpdate($data,$package)
+    {
         $package->setReference($data['reference']);
         $package->setOuterWidth($data['outerWidth']);
         $package->setOuterLength($data['outerLength']);

--- a/src/VividStore/Shipping/ShippingMethod.php
+++ b/src/VividStore/Shipping/ShippingMethod.php
@@ -5,6 +5,7 @@ use Database;
 use View;
 use Illuminate\Filesystem\Filesystem;
 
+use \Concrete\Package\VividStore\Src\VividStore\Shipping\ShippingMethodTypeMethod as StoreShippingMethodTypeMethod;
 use \Concrete\Package\VividStore\Src\VividStore\Shipping\ShippingMethodType as StoreShippingMethodType;
 
 /**
@@ -67,12 +68,13 @@ class ShippingMethod
         }
         return $methods;
     }
-    
-    /*
-     * @smtm Shipping Method Type Method Object
-     * @smt Shipping Method Type Object
+
+    /**
+     * @param StoreShippingMethodTypeMethod $smtm
+     * @param StoreShippingMethodType $smt
      * @param string $smName
      * @param bool $smEnabled
+     * @return ShippingMethod
      */
     public static function add($smtm,$smt,$smName,$smEnabled)
     {
@@ -91,7 +93,7 @@ class ShippingMethod
         $this->setName($smName);
         $this->setEnabled($smEnabled);
         $this->save();
-        return $sm;
+        return $this;
     }
     public function save()
     {
@@ -124,6 +126,27 @@ class ShippingMethod
             View::element("checkout/shipping_methods");
         } else {
             View::element("checkout/shipping_methods","vivid_store");
+        }
+    }
+
+    public static function getActiveShippingMethod()
+    {
+        $smID = \Session::get('smID');
+        if($smID){
+            $sm = StoreShippingMethod::getByID($smID);
+            return $sm;
+        }
+    }
+
+    public static function getActiveShippingMethodName()
+    {
+        $sm = self::getActiveShippingMethod();
+        if($sm instanceof ShippingMethod){
+            $shippingMethodTypeName = $sm->getShippingMethodType()->getShippingMethodTypeName();
+            $shippingMethodName = $sm->getName();
+            $smName = $shippingMethodTypeName.": ".$shippingMethodName;
+        } else {
+            $smName = t("None");
         }
     }
 }

--- a/src/VividStore/Tax/Tax.php
+++ b/src/VividStore/Tax/Tax.php
@@ -61,4 +61,33 @@ class Tax
         return $taxes;
         
     }
+    public static function getConcatenatedTaxStrings()
+    {
+        $taxes = self::getTaxes();
+        $taxCalc = Config::get('vividstore.calculation');
+
+        $taxTotal = array();
+        $taxIncludedTotal = array();
+        $taxLabels = array();
+
+        foreach($taxes as $tax){
+            if ($taxCalc == 'extract') {
+                $taxIncludedTotal[] = $tax['taxamount'];
+            }  else {
+                $taxTotal[] = $tax['taxamount'];
+            }
+            $taxLabels[] = $tax['name'];
+        }
+
+        $taxTotal = implode(',',$taxTotal);
+        $taxIncludedTotal = implode(',',$taxIncludedTotal);
+        $taxLabels = implode(',',$taxLabels);
+
+        $taxStrings = array(
+            'taxTotal' => $taxTotal,
+            'taxIncludedTotal' => $taxIncludedTotal,
+            'taxLabels' => $taxLabels
+        );
+        return $taxStrings;
+    }
 }

--- a/src/VividStore/Utilities/Calculator.php
+++ b/src/VividStore/Utilities/Calculator.php
@@ -10,7 +10,7 @@ use Session;
 
 class Calculator
 {
-    public function getSubTotal()
+    public static function getSubTotal()
     {
         $cart = StoreCart::getCart();
         $subtotal = 0;
@@ -27,7 +27,7 @@ class Calculator
         }
         return max($subtotal,0);
     }
-    public function getShippingTotal($smID = null)
+    public static function getShippingTotal($smID = null)
     {
         $sessionShippingMethodID = Session::get('smID');
         if($smID){
@@ -45,15 +45,15 @@ class Calculator
         }
         return $shippingTotal;
     }
-    public function getTaxTotals()
+    public static function getTaxTotals()
     {
         return StoreTax::getTaxes();
     }
-    public function getDiscountTotals()
+    public static function getDiscountTotals()
     {
         //should return 3 totals: subtotal, shipping, grand total
     }
-    public function getGrandTotal()
+    public static function getGrandTotal()
     {
         $subTotal = self::getSubTotal();
         $taxTotal = 0;
@@ -83,7 +83,7 @@ class Calculator
     }
 
     // returns an array of formatted cart totals
-    public function getTotals() {
+    public static function getTotals() {
         $subTotal = self::getSubTotal();
         $taxes = StoreTax::getTaxes();
         $addedTaxTotal = 0;

--- a/src/VividStore/Utilities/Installer.php
+++ b/src/VividStore/Utilities/Installer.php
@@ -79,7 +79,7 @@ class Installer
         }
         $productParentPage->setAttribute('exclude_nav', 1);
     }
-    public function installStoreProductPageType(Package $pkg){
+    public static function installStoreProductPageType(Package $pkg){
         //install product detail page type
         $pageType = PageType::getByHandle('store_product');
         if(!is_object($pageType)){
@@ -259,7 +259,7 @@ class Installer
         }
     }
     
-    public static function installUserAttributes(Package $package)
+    public static function installUserAttributes(Package $pkg)
     {
         //user attributes for customers
         $uakc = AttributeKeyCategory::getByHandle('user');


### PR DESCRIPTION
Two related things in this pull:
- on narrow screen/mobiles, as you move back and forth through the checkout panels it can often be disorientating or wrong in what/where it shows. This adds an automatic scroll to the next section to complete, with a focus on the first field.
- Instead of directly showing and hiding the panels, classes are added and removed, allowing for more flexibility with styling (adding highlighting, hiding headers, etc)
