### PR TITLE
Fix product option groups

### DIFF
--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -106,12 +106,12 @@ if(is_object($p)){?>
                 foreach($optionGroups as $optionGroup){
                 ?>
                 <div class="product-option-group vivid-store-col-2">
-                    <label class="option-group-label"><?=$optionGroup['pogName']?></label>
-                    <select name="pog<?=$optionGroup['pogID']?>">
+                    <label class="option-group-label"><?=$optionGroup->getName()?></label>
+                    <select name="pog<?=$optionGroup->getID()?>">
                         <?php
                         foreach($optionItems as $option){
-                            if($option['pogID']==$optionGroup['pogID']){?>
-                                <option value="<?=$option['poiID']?>"><?=$option['poiName']?></option>   
+                            if($option->getProductOptionGroupID()==$optionGroup->getID()){?>
+                                <option value="<?=$option->getID()?>"><?=$option->getName()?></option>
                             <?php }
                         }//foreach    
                         ?>

--- a/blocks/vivid_product_list/view.php
+++ b/blocks/vivid_product_list/view.php
@@ -63,12 +63,12 @@ if($products){
                 foreach($optionGroups as $optionGroup){
                     ?>
                     <div class="product-option-group">
-                        <label class="option-group-label"><?=$optionGroup['pogName']?></label>
-                        <select name="pog<?=$optionGroup['pogID']?>">
+                        <label class="option-group-label"><?=$optionGroup->getName()?></label>
+                        <select name="pog<?=$optionGroup->getID()?>">
                             <?php
                             foreach($optionItems as $option){
-                                if($option['pogID']==$optionGroup['pogID']){?>
-                                    <option value="<?=$option['poiID']?>"><?=$option['poiName']?></option>
+                                if($option->getID()==$optionGroup->getID()){?>
+                                    <option value="<?=$option->getID()?>"><?=$option->getName()?></option>
                                 <?php }
                             }//foreach
                             ?>

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -34,6 +34,8 @@ class Products extends DashboardPageController
         $products->setGroupID($gID);
         $products->activeOnly(false);
         $products->setShowOutOfStock(true);
+        $products->setSortBy('date');
+
 
         if ($this->get('keywords')) {
             $products->setSearch($this->get('keywords'));

--- a/elements/cart_list.php
+++ b/elements/cart_list.php
@@ -1,7 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
-use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
-use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
+use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionGroup as StoreProductOptionGroup;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
 ?>
 <ul class="checkout-cart-list">
     <?php
@@ -10,7 +12,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
         foreach ($cart as $k=>$cartItem){
             $pID = $cartItem['product']['pID'];
             $qty = $cartItem['product']['qty'];
-            $product = VividProduct::getByID($pID);
+            $product = StoreProduct::getByID($pID);
             if($i%2==0){$classes=" striped"; }else{ $classes=""; }
             if(is_object($product)){
                 ?>
@@ -28,7 +30,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                     </div>
 
                     <div class="checkout-cart-item-price">
-                        <?=Price::format($product->getActivePrice())?>
+                        <?=StorePrice::format($product->getActivePrice())?>
                     </div>
 
                     <?php if ($product->allowQuantity()) { ?>
@@ -42,10 +44,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                         <div class="checkout-cart-item-attributes">
                             <?php foreach($cartItem['productAttributes'] as $groupID => $valID){
                                 $groupID = str_replace("pog","",$groupID);
+                                $optiongroup = StoreProductOptionGroup::getByID($groupID);
+                                $optionvalue = StoreProductOptionItem::getByID($valID);
+
                                 ?>
                                 <div class="cart-list-item-attribute">
-                                    <span class="checkout-cart-item-attribute-label"><?=VividProduct::getProductOptionGroupNameByID($groupID)?>:</span>
-                                    <span class="checkout-cart-item-attribute-value"><?=VividProduct::getProductOptionValueByID($valID)?></span>
+                                    <span class="cart-list-item-attribute-label"><?= ($optiongroup ? $optiongroup->getName() : '')?>:</span>
+                                    <span class="cart-list-item-attribute-value"><?= ($optionvalue ? $optionvalue->getName(): '')?></span>
                                 </div>
                             <?php }  ?>
                         </div>

--- a/elements/cart_modal.php
+++ b/elements/cart_modal.php
@@ -1,7 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
-use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
-use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
+use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionGroup as StoreProductOptionGroup;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
 ?>
 <div class="cart-modal clearfix" id="cart-modal">
     <a href="javascript:vividStore.exitModal()" class="product-modal-exit">x</a>
@@ -41,7 +43,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                 foreach ($cart as $k=>$cartItem){
                     $pID = $cartItem['product']['pID'];
                     $qty = $cartItem['product']['qty'];
-                    $product = VividProduct::getByID($pID);
+                    $product = StoreProduct::getByID($pID);
                     if($i%2==0){$classes=" striped"; }else{ $classes=""; }
                     if(is_object($product)){
                         ?>
@@ -59,7 +61,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                             </div>
 
                             <div class="cart-list-item-price">
-                                <?=Price::format($product->getActivePrice())?>
+                                <?=StorePrice::format($product->getActivePrice())?>
                             </div>
 
                             <div class="cart-list-product-qty">
@@ -78,10 +80,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                                 <div class="cart-list-item-attributes">
                                     <?php foreach($cartItem['productAttributes'] as $groupID => $valID){
                                         $groupID = str_replace("pog","",$groupID);
+                                        $optiongroup = StoreProductOptionGroup::getByID($groupID);
+                                        $optionvalue = StoreProductOptionItem::getByID($valID);
+
                                         ?>
                                         <div class="cart-list-item-attribute">
-                                            <span class="cart-list-item-attribute-label"><?=VividProduct::getProductOptionGroupNameByID($groupID)?>:</span>
-                                            <span class="cart-list-item-attribute-value"><?=VividProduct::getProductOptionValueByID($valID)?></span>
+                                            <span class="cart-list-item-attribute-label"><?= ($optiongroup ? $optiongroup->getName() : '')?>:</span>
+                                            <span class="cart-list-item-attribute-value"><?= ($optionvalue ? $optionvalue->getName(): '')?></span>
                                         </div>
                                     <?php }  ?>
                                 </div>
@@ -102,7 +107,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
         <?php if ($cart  && !empty($cart)) { ?>
         <div class="cart-page-cart-total">
             <span class="cart-grand-total-label"><?=t("Sub Total")?>:</span>
-            <span class="cart-grand-total-value"><?=Price::format($total)?></span>
+            <span class="cart-grand-total-value"><?=StorePrice::format($total)?></span>
         </div>
         <?php } else { ?>
         <p class="alert alert-info"><?= t('Your cart is empty'); ?></p>

--- a/single_pages/cart.php
+++ b/single_pages/cart.php
@@ -1,7 +1,9 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
-use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
-use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
+use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionGroup as StoreProductOptionGroup;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
 ?>
 <div class="cart-page-cart">
 
@@ -34,7 +36,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
         foreach ($cart as $k=>$cartItem){
             $pID = $cartItem['product']['pID'];
             $qty = $cartItem['product']['qty'];
-            $product = VividProduct::getByID($pID);
+            $product = StoreProduct::getByID($pID);
             if($i%2==0){$classes=" striped"; }else{ $classes=""; }
             if(is_object($product)){
     ?>
@@ -55,10 +57,10 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
                 <?php 
                     $salePrice = $product->getProductSalePrice();
                     if(isset($salePrice) && $salePrice != ""){
-                        echo '<span class="original-price">'.Price::format($product->getProductPrice()).'</span>';
-                        echo '<span class="sale-price">'.Price::format($salePrice).'</span>';
+                        echo '<span class="original-price">'.StorePrice::format($product->getProductPrice()).'</span>';
+                        echo '<span class="sale-price">'.StorePrice::format($salePrice).'</span>';
                     } else {
-                        echo Price::format($product->getProductPrice());
+                        echo StorePrice::format($product->getProductPrice());
                     }
                 ?>
             </div>
@@ -83,10 +85,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
             <div class="cart-list-item-attributes">
                 <?php foreach($cartItem['productAttributes'] as $groupID => $valID){
                     $groupID = str_replace("pog","",$groupID);
+                    $optiongroup = StoreProductOptionGroup::getByID($groupID);
+                    $optionvalue = StoreProductOptionItem::getByID($valID);
+
                     ?>
                     <div class="cart-list-item-attribute">
-                        <span class="cart-list-item-attribute-label"><?=VividProduct::getProductOptionGroupNameByID($groupID)?>:</span>
-                        <span class="cart-list-item-attribute-value"><?=VividProduct::getProductOptionValueByID($valID)?></span>
+                        <span class="cart-list-item-attribute-label"><?= ($optiongroup ? $optiongroup->getName() : '')?>:</span>
+                        <span class="cart-list-item-attribute-value"><?= ($optionvalue ? $optionvalue->getName(): '')?></span>
                     </div>
                 <?php }  ?>
             </div>    
@@ -133,7 +138,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as Price;
     <?php if ($cart  && !empty($cart)) { ?>
     <div class="cart-page-cart-total">        
         <span class="cart-grand-total-label"><?=t("Sub Total")?>:</span>
-        <span class="cart-grand-total-value"><?=Price::format($total)?></span>
+        <span class="cart-grand-total-value"><?=StorePrice::format($total)?></span>
     </div>
         
     <div class="cart-page-cart-links">

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -426,7 +426,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             </div><!-- #product-images -->
 
 
-
             <div class="col-sm-7 store-pane" id="product-options">
 
                 <h4><?=t('Options')?></h4>
@@ -455,7 +454,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         <div class="panel-body">
                             <div data-group="<%=sort%>" class="option-group-item-container"></div>
                         </div>
-                        <input type="hidden" name="pogID" value="<%=pogID%>">
+                        <input type="hidden" name="pogID[]" value="<%=pogID%>">
                         <input type="hidden" name="pogSort[]" value="<%=sort%>" class="option-group-sort">
                     </div><!-- .option-group -->
                 </script>
@@ -484,15 +483,15 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         var optionsContainer = $('#product-options-container');
                         var optionsTemplate = _.template($('#option-group-template').html());
 
-                        //load up images
+                        //load up existing option groups
                         <?php
                         if($groups) {
                             foreach ($groups as $group) {
                         ?>
                         optionsContainer.append(optionsTemplate({
-                            pogName: '<?php echo $group['pogName'] ?>',
-                            pogID: '<?php echo $group['pogID']?>',
-                            sort: '<?=$group['pogSort'] ?>'
+                            pogName: '<?php echo $group->getName() ?>',
+                            pogID: '<?php echo $group->getID()?>',
+                            sort: '<?=$group->getSort() ?>'
                         }));
                         <?php
                             }
@@ -527,6 +526,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             </div>
                             <div class="col-sm-5">
                                 <input type="text" name="poiName[]" class="form-control" value="<%=poiName%>">
+                                <input type="hidden" name="poiID[]" class="form-control" value="<%=poiID%>">
                             </div>
                             <div class="col-sm-2">
                                 <a href="javascript:deleteOptionItem(<%=optGroup%>,<%=sort%>);" class="btn btn-danger"><i class="fa fa-trash"></i></a>
@@ -560,6 +560,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         optItemsContainer.append(optItemsTemplate({
                             //vars to pass to the template
                             poiName: '',
+                            poiID: '',
                             optGroup: group,
                             sort: temp
                         }));
@@ -588,12 +589,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             for($i=0;$i<$count;$i++){
                                 foreach($optItems as $option){
                                     //go through all options, see if it belongs in the group we're on in the for loop
-                                    if($option['pogID'] == $groups[$i]['pogID']){?>
+                                    if($option->getProductOptionGroupID() == $groups[$i]->getID()){?>
                         var optItemsContainer = $(".option-group-item-container[data-group='<?=$i?>']");
                         optItemsContainer.append(optItemsTemplate({
-                            poiName: '<?=$option['poiName']?>',
+                            poiName: '<?=$option->getName()?>',
+                            poiID: '<?=$option->getID()?>',
                             optGroup: <?=$i?>,
-                            sort: <?=$option['poiSort']?>
+                            sort: <?=$option->getSort()?>
 
                         }));
                         <?php

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -57,53 +57,51 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             <div class="col-sm-7 store-pane active" id="product-overview">
 
                 <div class="row">
-                    <div class="col-xs-6">
+                    <div class="col-xs-12">
                         <div class="form-group">
                             <?php echo $form->label("pName", t("Product Name"));?>
                             <?php echo $form->text("pName", $p->getProductName());?>
                         </div>
                     </div>
+                </div>
+
+                <div class="row">
                     <div class="col-xs-6">
                         <div class="form-group">
                             <?php echo $form->label("pActive", t("Active"));?>
                             <?php echo $form->select("pActive", array('1'=>t('Active'),'0'=>t('Inactive')), $p->isActive());?>
                         </div>
                     </div>
+                    <div class="col-xs-6">
+                        <div class="form-group">
+                            <?php echo $form->label("pFeatured", t("Featured Product"));?>
+                            <?php echo $form->select("pFeatured",array('0'=>t('No'),'1'=>t('Yes')), $p->isFeatured());?>
+                        </div>
+                    </div>
                 </div>
-                
                 <div class="row">
                     <div class="col-xs-6">
-                        <div class="row">
-                            <div class="col-xs-6">
-                                <div class="form-group">
-                                    <?php echo $form->label("pPrice", t("Price"));?>
-                                    <div class="input-group">
-                                        <div class="input-group-addon">
-                                            <?= Config::get('vividstore.symbol');?>
-                                        </div>
-                                        <?php $price = $p->getProductPrice(); ?>
-                                        <?php echo $form->text("pPrice", $price?$price:'0');?>
-                                    </div>
+                        <div class="form-group">
+                            <?php echo $form->label("pPrice", t("Price"));?>
+                            <div class="input-group">
+                                <div class="input-group-addon">
+                                    <?= Config::get('vividstore.symbol');?>
                                 </div>
-                            </div>
-                            <div class="col-xs-6">
-                                <div class="form-group">
-                                    <?php echo $form->label("pSalePrice", t("Sale Price"));?>
-                                    <div class="input-group">
-                                        <div class="input-group-addon">
-                                            <?= Config::get('vividstore.symbol');?>
-                                        </div>
-                                        <?php $salePrice = $p->getProductSalePrice(); ?>
-                                        <?php echo $form->text("pSalePrice", $salePrice);?>
-                                    </div>
-                                </div>
+                                <?php $price = $p->getProductPrice(); ?>
+                                <?php echo $form->text("pPrice", $price?$price:'0');?>
                             </div>
                         </div>
                     </div>
                     <div class="col-xs-6">
                         <div class="form-group">
-                            <?php echo $form->label("pFeatured", t("Featured Product"));?>
-                            <?php echo $form->select("pFeatured",array('0'=>t('No'),'1'=>t('Yes')), $p->isFeatured());?>
+                            <?php echo $form->label("pSalePrice", t("Sale Price"));?>
+                            <div class="input-group">
+                                <div class="input-group-addon">
+                                    <?= Config::get('vividstore.symbol');?>
+                                </div>
+                                <?php $salePrice = $p->getProductSalePrice(); ?>
+                                <?php echo $form->text("pSalePrice", $salePrice);?>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -258,7 +258,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
                 <div class="form-group">
                     <?php echo $form->label("pShippable", t("Product is Shippable"));?>
-                    <?php echo $form->select("pShippable",array('1'=>t('Yes'),'0'=>t('No')), $p->isShippable());?>
+                    <?php echo $form->select("pShippable",array('1'=>t('Yes'),'0'=>t('No')), ($p->isShippable() ? '1' : '0'));?>
                 </div>
                 
                 <div class="alert alert-info">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -31,7 +31,7 @@
                     
                     <div class="form-group">
                         <?php echo $form->label('symbol',t('Currency Symbol')); ?>
-                        <?php echo $form->text('symbol',Config::get('vividstore.symbol'),array("style"=>"width:60px;"));?>
+                        <?php echo $form->text('symbol',Config::get('vividstore.symbol'),array("style"=>"width:80px;"));?>
                     </div>
                     <div class="form-group">
                         <?php echo $form->label('thousand',t('Thousands Separator %se.g. , or a space%s', "<small>", "</small>")); ?>

--- a/src/VividStore/Product/Product.php
+++ b/src/VividStore/Product/Product.php
@@ -19,6 +19,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\ProductLocation as Store
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionGroup as StoreProductOptionGroup;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
 use \Concrete\Package\VividStore\Src\Attribute\Key\StoreProductKey;
+use \Concrete\Package\VividStore\Src\Attribute\Value\StoreProductValue;
 use \Concrete\Package\VividStore\Src\VividStore\Tax\TaxClass as StoreTaxClass;
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
 
@@ -156,17 +157,17 @@ class Product
     public function setProductDetail($detail){ $this->pDetail = $detail; }
     public function setProductPrice($price){ $this->pPrice = $price; }
     public function setProductSalePrice($price){ $this->pSalePrice = ($price != '' ? $price : null); }
-    public function setIsFeatured($bool){ $this->pFeatured = $bool; }
+    public function setIsFeatured($bool){ $this->pFeatured = (!is_null($bool) ? $bool : false); }
     public function setProductQty($qty){ $this->pQty = ($qty ? $qty : 0);  }
-    public function setIsUnlimited($bool){ $this->pQtyUnlim = $bool; }
-    public function setAllowBackOrder($bool){ $this->pBackOrder = $bool; }
+    public function setIsUnlimited($bool){ $this->pQtyUnlim = (!is_null($bool) ? $bool : false); }
+    public function setAllowBackOrder($bool){ $this->pBackOrder = (!is_null($bool) ? $bool : false); }
     public function setNoQty($bool){ $this->pNoQty = $bool; }
     public function setProductTaxClass($taxClass){ $this->pTaxClass = $taxClass; }
-    public function setIsTaxable($bool){ $this->pTaxable = $bool; }
+    public function setIsTaxable($bool){ $this->pTaxable = (!is_null($bool) ? $bool : false); }
     public function setProductImageID($fID){ $this->pfID = $fID; }
     public function setIsActive($bool){ $this->pActive = $bool; }
     public function setProductDateAdded($date){ $this->pDateAdded = $date; }
-    public function setIsShippable($bool){ $this->pShippable = $bool; }
+    public function setIsShippable($bool){ $this->pShippable = (!is_null($bool) ? $bool : false); }
     public function setProductWidth($width){ $this->pWidth = $width; }
     public function setProductHeight($height){ $this->pHeight = $height; }
     public function setProductLength($length){ $this->pLength = $length; }

--- a/src/VividStore/Product/ProductOption/ProductOption.php
+++ b/src/VividStore/Product/ProductOption/ProductOption.php
@@ -10,17 +10,39 @@ class ProductOption
 {
     public static function addProductOptions($data,$product)
     {
+
+        StoreProductOptionGroup::removeOptionGroupsForProduct($product, $data['pogID']);
+        StoreProductOptionItem::removeOptionItemsForProduct($product, $data['poiID']);
+
         $count = count($data['pogSort']);
         $ii=0;//set counter for items
         if($count>0){
             for($i=0;$i<count($data['pogSort']);$i++){
-                $optionGroup = StoreProductOptionGroup::add($product,$data['pogName'][$i],$data['pogSort'][$i]);
-                $pogID = $optionGroup->getID();         
+
+                if (isset($data['pogID'][$i])) {
+                    $optionGroup = StoreProductOptionGroup::getByID($data['pogID'][$i]);
+
+                    if ($optionGroup) {
+                        $optionGroup->update($product,$data['pogName'][$i],$data['pogSort'][$i]);
+                    }
+                }
+
+                if (!$optionGroup) {
+                    $optionGroup = StoreProductOptionGroup::add($product,$data['pogName'][$i],$data['pogSort'][$i]);
+                }
+
+                $pogID = $optionGroup->getID();
                 //add option items
                 $itemsInGroup = count($data['optGroup'.$i]);
                 if($itemsInGroup>0){
                     for($gi=0;$gi<$itemsInGroup;$gi++,$ii++){
-                        StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii]);
+
+                        if ($data['poiID'][$ii] > 0) {
+                            $option = StoreProductOptionItem::getByID($data['poiID'][$ii]);
+                            $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                        } else {
+                            StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                        }
                     }
                 }
             }

--- a/src/VividStore/Product/ProductOption/ProductOptionGroup.php
+++ b/src/VividStore/Product/ProductOption/ProductOptionGroup.php
@@ -24,20 +24,21 @@ class ProductOptionGroup
     protected $pID; 
     
     /**
-     * @Column(type="integer")
+     * @Column(type="string")
      */
     protected $pogName;
     
     /**
      * @Column(type="integer")
      */
-    protected $pogSort; 
-    
+    protected $pogSort;
+
+    private function setID($pogID){ $this->pogID = $pogID; }
     private function setProductID($pID){ $this->pID = $pID; }
     private function setName($name){ $this->pogName = $name; }
     private function setSort($sort){ $this->pogSort = $sort; }
     
-    public function getID(){ return $this->piID; }
+    public function getID(){ return $this->pogID; }
     public function getProductID() { return $this->pID; }
     public function getName() { return $this->pogName; }
     public function getSort() { return $this->pogSort; }
@@ -55,12 +56,18 @@ class ProductOptionGroup
         return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionGroup')->findBy(array('pID' => $product->getProductID()));
     }
     
-    public static function removeOptionGroupsForProduct(StoreProduct $product)
+    public static function removeOptionGroupsForProduct(StoreProduct $product, $excluding = array())
     {
+        if (!is_array($excluding)) {
+            $excluding = array();
+        }
+
         //clear out existing product option groups
         $existingOptionGroups = self::getOptionGroupsForProduct($product);
         foreach($existingOptionGroups as $optionGroup){
-            $optionGroup->delete();
+            if (!in_array($optionGroup->getID(), $excluding)) {
+                $optionGroup->delete();
+            }
         }
     }
     
@@ -76,7 +83,7 @@ class ProductOptionGroup
         $pID = $product->getProductID();
         return self::addOrUpdate($pID,$name,$sort,$productOptionGroup);
     }
-    public static function addOrUpdate($pID,$fID,$sort,$obj)
+    public static function addOrUpdate($pID,$name,$sort,$obj)
     {
         $obj->setProductID($pID);
         $obj->setName($name);

--- a/src/VividStore/Product/ProductOption/ProductOptionItem.php
+++ b/src/VividStore/Product/ProductOption/ProductOptionItem.php
@@ -12,98 +12,115 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product\ProductOption\Pr
  */
 class ProductOptionItem
 {
-    
-    /** 
-     * @Id @Column(type="integer") 
-     * @GeneratedValue 
+
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
      */
     protected $poiID;
-    
+
     /**
      * @Column(type="integer")
      */
-    protected $pID; 
-    
+    protected $pID;
+
     /**
      * @Column(type="integer")
      */
     protected $pogID;
-    
+
     /**
      * @Column(type="string")
      */
-    protected $poiName; 
-    
+    protected $poiName;
+
     /**
      * @Column(type="integer")
      */
-    protected $poiSort; 
-    
+    protected $poiSort;
+
     private function setProductID($pID){ $this->pID = $pID; }
     private function setProductOptionGroupID($id){ $this->pogID = $id; }
     private function setProductOptionItemName($name){ $this->poiName = $name; }
     private function setSort($sort){ $this->poiSort = $sort; }
-    
-    public function getID(){ return $this->piID; }
+    private function setName($name){ $this->poiName = $name; }
+
+    public function getID(){ return $this->poiID; }
     public function getProductID() { return $this->pID; }
     public function getProductOptionGroupID() { return $this->pogID; }
     public function getName(){ return $this->poiName; }
     public function getSort() { return $this->poiSort; }
-    
+
     public static function getByID($id) {
         $db = Database::connection();
         $em = $db->getEntityManager();
         return $em->find('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem', $id);
     }
-    
+
     public static function getOptionItemsForProduct(StoreProduct $product)
     {
         $db = Database::connection();
         $em = $db->getEntityManager();
-        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pID' => $product->getProductID()));
+        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pID' => $product->getProductID()), array('poiSort'=>'asc'));
     }
-    
+
     public static function getOptionItemsForProductOptionGroup(ProductOptionGroup $pog)
     {
         $db = Database::connection();
         $em = $db->getEntityManager();
-        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pogID' => $pog->getID()));
+        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pogID' => $pog->getID()), array('poiSort'=>'asc'));
     }
-    
-    public static function removeOptionItemsForProduct(StoreProduct $product)
+
+    public static function removeOptionItemsForProduct(StoreProduct $product, $excluding = array())
     {
+        if (!is_array($excluding)) {
+            $excluding = array();
+        }
+
         //clear out existing product option items
         $existingOptionItems = self::getOptionItemsForProduct($product);
         foreach($existingOptionItems as $optionItem){
-            $optionItem->delete();
+            if (!in_array($optionItem->getID(), $excluding)) {
+                $optionItem->delete();
+            }
         }
     }
-    
+
     public static function add(StoreProduct $product,$pogID,$name,$sort)
     {
         $productOptionItem = new self();
         $pID = $product->getProductID();
         $productOptionItem->setProductID($pID);
         $productOptionItem->setProductOptionGroupID($pogID);
-        $productOptionItem->setName($name);
+        $productOptionItem->setProductOptionItemName($name);
         $productOptionItem->setSort($sort);
-        $obj->save();
+        $productOptionItem->save();
         return $productOptionItem;
     }
-    
-    
+
+
+    public function update(StoreProduct $product,$name,$sort)
+    {
+        $pID = $product->getProductID();
+        $this->setProductID($pID);
+        $this->setName($name);
+        $this->setSort($sort);
+        $this->save();
+        return $this;
+    }
+
     public function save()
     {
         $em = Database::connection()->getEntityManager();
         $em->persist($this);
         $em->flush();
     }
-    
+
     public function delete()
     {
         $em = Database::connection()->getEntityManager();
         $em->remove($this);
         $em->flush();
     }
-    
+
 }


### PR DESCRIPTION
This fixes (at least to a reasonable state) adding and editing product options and option items.
It also fixes the shippable selector for products. 
Also sets the default order to date added when listing products in the dashboard.
