### PR TITLE
Require jquery, fix for some JS errors with cachingon 

### DIFF
--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -50,6 +50,7 @@ class Controller extends BlockController
                 var QTYMESSAGE = '".t('Quantity must be greater than zero')."';
             </script>
         ");
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
         $this->requireAsset('core/lightbox');

--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -43,6 +43,8 @@ class Controller extends BlockController
     {
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('css', 'vivid-store');
         $this->requireAsset('core/lightbox');
     }

--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -41,15 +41,6 @@ class Controller extends BlockController
     }
     public function registerViewAssets()
     {
-        
-        $this->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '".View::url('/productmodal')."';
-                var CARTURL = '".View::url('/cart')."';
-                var CHECKOUTURL = '".View::url('/checkout')."';
-                var QTYMESSAGE = '".t('Quantity must be greater than zero')."';
-            </script>
-        ");
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -114,6 +114,8 @@ class Controller extends BlockController
     public function registerViewAssets()
     {
         $this->requireAsset('javascript', 'jquery');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
     }

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -113,14 +113,6 @@ class Controller extends BlockController
     }
     public function registerViewAssets()
     {
-        $this->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '".View::url('/productmodal')."';
-                var CARTURL = '".View::url('/cart')."';
-                var CHECKOUTURL = '".View::url('/checkout')."';
-                var QTYMESSAGE = '".t('Quantity must be greater than zero')."';
-            </script>
-        ");
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -121,6 +121,7 @@ class Controller extends BlockController
                 var QTYMESSAGE = '".t('Quantity must be greater than zero')."';
             </script>
         ");
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
     }

--- a/blocks/vivid_utility_links/controller.php
+++ b/blocks/vivid_utility_links/controller.php
@@ -34,6 +34,8 @@ class Controller extends BlockController
     public function registerViewAssets()
     {
         $this->requireAsset('javascript', 'jquery');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
     }

--- a/blocks/vivid_utility_links/controller.php
+++ b/blocks/vivid_utility_links/controller.php
@@ -34,6 +34,7 @@ class Controller extends BlockController
 
     public function registerViewAssets()
     {
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
 

--- a/blocks/vivid_utility_links/controller.php
+++ b/blocks/vivid_utility_links/controller.php
@@ -31,23 +31,12 @@ class Controller extends BlockController
         $this->set("total",StorePrice::format(StoreCalculator::getSubTotal()));
 
     }
-
     public function registerViewAssets()
     {
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
-
-        $this->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '".View::url('/productmodal')."';
-                var CARTURL = '".View::url('/cart')."';
-                var CHECKOUTURL = '".View::url('/checkout')."';
-                var QTYMESSAGE = '".t('Quantity must be greater than zero')."';
-            </script>
-        ");
     }
-
     public function save($args)
     {
         $args['showCartItems'] = isset($args['showCartItems']) ? 1 : 0;

--- a/controller.php
+++ b/controller.php
@@ -110,15 +110,6 @@ class Controller extends Package
                 array('css', 'chartist'),
             )
         );
-
-        View::getInstance()->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '" . View::url('/productmodal') . "';
-                var CARTURL = '" . View::url('/cart') . "';
-                var CHECKOUTURL = '" . View::url('/checkout') . "';
-                var QTYMESSAGE = '" . t('Quantity must be greater than zero') . "';
-            </script>
-            ");
     }
     public function uninstall()
     {
@@ -144,6 +135,18 @@ class Controller extends Package
             $shippingMethodType->delete();
         }
         parent::uninstall();
+    }
+
+    public static function returnHeaderJS()
+    {
+        return "
+        <script type=\"text/javascript\">
+            var PRODUCTMODAL = '" . View::url('/productmodal') . "';
+            var CARTURL = '" . View::url('/cart') . "';
+            var CHECKOUTURL = '" . View::url('/checkout') . "';
+            var QTYMESSAGE = '" . t('Quantity must be greater than zero') . "';
+        </script>
+        ";
     }
 
 

--- a/controller.php
+++ b/controller.php
@@ -8,6 +8,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Utilities\Installer;
 use Route;
 use Asset;
 use AssetList;
+use View;
 
 class Controller extends Package
 {
@@ -109,6 +110,15 @@ class Controller extends Package
                 array('css', 'chartist'),
             )
         );
+
+        View::getInstance()->addHeaderItem("
+            <script type=\"text/javascript\">
+                var PRODUCTMODAL = '" . View::url('/productmodal') . "';
+                var CARTURL = '" . View::url('/cart') . "';
+                var CHECKOUTURL = '" . View::url('/checkout') . "';
+                var QTYMESSAGE = '" . t('Quantity must be greater than zero') . "';
+            </script>
+            ");
     }
     public function uninstall()
     {

--- a/controllers/single_page/cart.php
+++ b/controllers/single_page/cart.php
@@ -50,13 +50,7 @@ class Cart extends PageController
         $this->set('cart',StoreCart::getCart());
         $this->set('discounts',StoreCart::getDiscounts());
         $this->set('total',StoreCalculator::getSubTotal());
-        $this->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '".View::url('/productmodal')."';
-                var CARTURL = '".View::url('/cart')."';
-                var CHECKOUTURL = '".View::url('/checkout')."';
-            </script>
-        ");
+        
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');

--- a/controllers/single_page/cart.php
+++ b/controllers/single_page/cart.php
@@ -52,6 +52,8 @@ class Cart extends PageController
         $this->set('total',StoreCalculator::getSubTotal());
         
         $this->requireAsset('javascript', 'jquery');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
 

--- a/controllers/single_page/cart.php
+++ b/controllers/single_page/cart.php
@@ -57,6 +57,7 @@ class Cart extends PageController
                 var CHECKOUTURL = '".View::url('/checkout')."';
             </script>
         ");
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
 

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -107,14 +107,6 @@ class Checkout extends PageController
         $this->set('total',$totals['total']);
         $this->set('shippingEnabled', StoreCart::isShippable());
 
-        $this->addHeaderItem("
-            <script type=\"text/javascript\">
-                var PRODUCTMODAL = '".View::url('/productmodal')."';
-                var CARTURL = '".View::url('/cart')."';
-                var CHECKOUTURL = '".View::url('/checkout')."';
-            </script>
-        ");
-
         $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -108,6 +108,8 @@ class Checkout extends PageController
         $this->set('shippingEnabled', StoreCart::isShippable());
 
         $this->requireAsset('javascript', 'jquery');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
         $this->addFooterItem("

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -21,8 +21,6 @@ class Checkout extends PageController
 {
     public function view()
     {
-        $pkg = Package::getByHandle('vivid_store');
-
         $customer = new StoreCustomer();
         $this->set('customer', $customer);
         $guestCheckout = Config::get('vividstore.guestCheckout');
@@ -117,6 +115,7 @@ class Checkout extends PageController
             </script>
         ");
 
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
         $this->addFooterItem("

--- a/controllers/single_page/checkout/complete.php
+++ b/controllers/single_page/checkout/complete.php
@@ -21,6 +21,7 @@ class Complete extends PageController
         } else {
             $this->redirect("/cart");
         }
+        $this->requireAsset('javascript', 'jquery');
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
     }

--- a/controllers/single_page/checkout/complete.php
+++ b/controllers/single_page/checkout/complete.php
@@ -22,6 +22,8 @@ class Complete extends PageController
             $this->redirect("/cart");
         }
         $this->requireAsset('javascript', 'jquery');
+        $js = \Concrete\Package\VividStore\Controller::returnHeaderJS();
+        $this->addFooterItem($js);
         $this->requireAsset('javascript', 'vivid-store');
         $this->requireAsset('css', 'vivid-store');
     }


### PR DESCRIPTION
This addresses #237

It also refactors the way some of the javascript variables get injected into the page, moving this from the blocks' registerViewAssets function to the package on_start. Previously, with caching on, the javascript values weren't being injected into the page (kind of a concrete5 bug), causing errors in vivid-store.js.
