### PR TITLE
Css only spinner

### DIFF
--- a/css/vivid-store.css
+++ b/css/vivid-store.css
@@ -25,9 +25,19 @@
 
 /* Loading/Modal */
 .whiteout { position: fixed; z-index: 99; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); }
-    .vivid-store-spinner { position: absolute; top: 50%; left: 48%; background: #fff; padding: 20px; border: 1px solid #ccc; box-shadow: 0 0 10px rgba(0,0,0,0.4); }
-    .whiteout .fa-spinner { font-size: 30px; }
-    
+    .vivid-store-spinner-container { position: absolute; top: 50%; left: 50%; margin-top:-35px; margin-left: -35px; background: #fff; padding: 20px; }
+    .vivid-store-spinner { min-width: 30px; min-height: 30px; }
+    .vivid-store-spinner:before { content: '...'; text-align: center; position: absolute; top: 50%; left: 50%; width: 20px; height: 20px; margin-top: -16px; margin-left: -16px; font-size: 36px; line-height: 16px; font-family: arial, san-serif; /* Non animation fallback */}
+    .vivid-store-spinner:not(:required):before { content: ''; border-radius: 50%; border: 6px solid rgba(0, 0, 0, .3); border-top-color: rgba(0, 0, 0, .6); animation: spinner .6s linear infinite; -webkit-animation: spinner .6s linear infinite; }
+
+    @keyframes spinner {
+        to {transform: rotate(360deg);}
+    }
+
+    @-webkit-keyframes spinner {
+        to {-webkit-transform: rotate(360deg);}
+    }
+
     .product-modal, .cart-modal { background: #fff; position: relative; top: 15%; width: 100%; max-width: 600px; max-height: 75%; overflow: auto; margin: 0 auto;  box-shadow: 0 0 10px rgba(0,0,0,0.4); padding: 20px; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
         .product-modal-thumb { float: left; width: 40%; }
             .product-modal-thumb img { max-width: 100%; height: auto; }

--- a/css/vivid-store.css
+++ b/css/vivid-store.css
@@ -25,10 +25,10 @@
 
 /* Loading/Modal */
 .whiteout { position: fixed; z-index: 99; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); }
-    .vivid-store-spinner-container { position: absolute; top: 50%; left: 50%; margin-top:-35px; margin-left: -35px; background: #fff; padding: 20px; }
-    .vivid-store-spinner { min-width: 30px; min-height: 30px; }
-    .vivid-store-spinner:before { content: '...'; text-align: center; position: absolute; top: 50%; left: 50%; width: 20px; height: 20px; margin-top: -16px; margin-left: -16px; font-size: 36px; line-height: 16px; font-family: arial, san-serif; /* Non animation fallback */}
-    .vivid-store-spinner:not(:required):before { content: ''; border-radius: 50%; border: 6px solid rgba(0, 0, 0, .3); border-top-color: rgba(0, 0, 0, .6); animation: spinner .6s linear infinite; -webkit-animation: spinner .6s linear infinite; }
+    .vivid-store-spinner-container { position: absolute; top: 50%; left: 50%; margin-top:-33px; margin-left: -33px; background: #fff; padding: 20px; }
+    .vivid-store-spinner { min-width: 26px; min-height: 26px; }
+    .vivid-store-spinner:before { content: '...'; text-align: center; position: absolute; top: 50%; left: 50%; width: 20px; height: 20px; margin-top: -14px; margin-left: -14px; font-size: 36px; line-height: 16px; font-family: arial, san-serif; /* Non animation fallback */}
+    .vivid-store-spinner:not(:required):before { content: ''; border-radius: 50%; border: 4px solid rgba(0, 0, 0, .2); border-top-color: rgba(0, 0, 0, .6); animation: spinner .6s linear infinite; -webkit-animation: spinner .6s linear infinite; }
 
     @keyframes spinner {
         to {transform: rotate(360deg);}

--- a/css/vivid-store.css
+++ b/css/vivid-store.css
@@ -28,7 +28,7 @@
     .vivid-store-spinner-container { position: absolute; top: 50%; left: 50%; margin-top:-33px; margin-left: -33px; background: #fff; padding: 20px; }
     .vivid-store-spinner { min-width: 26px; min-height: 26px; }
     .vivid-store-spinner:before { content: '...'; text-align: center; position: absolute; top: 50%; left: 50%; width: 20px; height: 20px; margin-top: -14px; margin-left: -14px; font-size: 36px; line-height: 16px; font-family: arial, san-serif; /* Non animation fallback */}
-    .vivid-store-spinner:not(:required):before { content: ''; border-radius: 50%; border: 4px solid rgba(0, 0, 0, .2); border-top-color: rgba(0, 0, 0, .6); animation: spinner .6s linear infinite; -webkit-animation: spinner .6s linear infinite; }
+    .vivid-store-spinner:not(:required):before { content: ''; border-radius: 50%; border: 4px solid rgba(0, 0, 0, .2); border-top-color: rgba(0, 0, 0, .6); animation: spinner .6s linear infinite; -webkit-animation: spinner .6s linear infinite; box-sizing: content-box;}
 
     @keyframes spinner {
         to {transform: rotate(360deg);}

--- a/js/vivid-store.js
+++ b/js/vivid-store.js
@@ -21,7 +21,7 @@ openModal: function(content) {
 }
 ,
 waiting: function(){
-    vividStore.openModal("<div class='vivid-store-spinner'><i class='fa fa-spinner fa-spin'></i></div>");
+    vividStore.openModal("<div class='vivid-store-spinner-container'><div class='vivid-store-spinner'></div></div>");
 },
 
 exitModal: function(){


### PR DESCRIPTION
The existing spinner requires font-awesome to be required in themes. 
It's the only place where it's required, so it's kind of annoying to have to include it just for the spinner.

This implements a CSS only spinner. For browsers that don't support the CSS, it falls back to showing a couple of dots. It's pretty easy to change colours, etc.

This also fixes the positioning of the spinner in the browser, which wasn't always right in the center on smaller screens.
