### PR TITLE
Feature - product variations

### DIFF
--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -9,6 +9,7 @@ use Page;
 use URL;
 
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation as StoreProductVariation;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 class Controller extends BlockController
@@ -37,6 +38,25 @@ class Controller extends BlockController
         } else {
             $p = StoreProduct::getByID($this->pID);
         }
+
+        if ($p->hasVariations()) {
+            $variations = StoreProductVariation::getVariationsForProduct($p);
+
+            $variationLookup = array();
+
+            if (!empty($variations)) {
+                foreach ($variations as $variation) {
+                    // returned pre-sorted
+                    $ids = $variation->getOptionItemIDs();
+                    $variationLookup[implode('_', $ids)] = $variation;
+                }
+
+                $p->setVariation($variations[0]);
+            }
+
+            $this->set('variationLookup', $variationLookup);
+        }
+
         $this->set('p',$p);
     }
     public function registerViewAssets()

--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -39,24 +39,30 @@ class Controller extends BlockController
             $product = StoreProduct::getByID($this->pID);
         }
 
-        if ($product->hasVariations()) {
-            $variations = StoreProductVariation::getVariationsForProduct($product);
+        if ($product) {
 
-            $variationLookup = array();
 
-            if (!empty($variations)) {
-                foreach ($variations as $variation) {
-                    // returned pre-sorted
-                    $ids = $variation->getOptionItemIDs();
-                    $variationLookup[implode('_', $ids)] = $variation;
+            if ($product->hasVariations()) {
+                $variations = StoreProductVariation::getVariationsForProduct($product);
+
+                $variationLookup = array();
+
+                if (!empty($variations)) {
+                    foreach ($variations as $variation) {
+                        // returned pre-sorted
+                        $ids = $variation->getOptionItemIDs();
+                        $variationLookup[implode('_', $ids)] = $variation;
+                    }
                 }
+
+                $product->setInitialVariation();
+                $this->set('variationLookup', $variationLookup);
             }
 
-            $product->setInitialVariation();
-            $this->set('variationLookup', $variationLookup);
+            $this->set('product',$product);
+            $this->set('optionGroups', $product->getProductOptionGroups());
+            $this->set('optionItems',$product->getProductOptionItems(true));
         }
-
-        $this->set('product',$product);
     }
     public function registerViewAssets()
     {

--- a/blocks/vivid_product/controller.php
+++ b/blocks/vivid_product/controller.php
@@ -34,13 +34,13 @@ class Controller extends BlockController
             
         if($this->productLocation == 'page'){
             $cID = Page::getCurrentPage()->getCollectionID();
-            $p = StoreProduct::getByCollectionID($cID);
+            $product = StoreProduct::getByCollectionID($cID);
         } else {
-            $p = StoreProduct::getByID($this->pID);
+            $product = StoreProduct::getByID($this->pID);
         }
 
-        if ($p->hasVariations()) {
-            $variations = StoreProductVariation::getVariationsForProduct($p);
+        if ($product->hasVariations()) {
+            $variations = StoreProductVariation::getVariationsForProduct($product);
 
             $variationLookup = array();
 
@@ -50,14 +50,13 @@ class Controller extends BlockController
                     $ids = $variation->getOptionItemIDs();
                     $variationLookup[implode('_', $ids)] = $variation;
                 }
-
-                $p->setVariation($variations[0]);
             }
 
+            $product->setInitialVariation();
             $this->set('variationLookup', $variationLookup);
         }
 
-        $this->set('p',$p);
+        $this->set('product',$product);
     }
     public function registerViewAssets()
     {

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -108,26 +108,32 @@ if(is_object($product)){?>
                     <input type="hidden" name="quantity" class="product-qty" value="1">
                 <?php } ?>
                 <?php
-                $optionGroups = $product->getProductOptionGroups();
-                $optionItems = $product->getProductOptionItems();
-                foreach($optionGroups as $optionGroup){
-                ?>
-                <div class="product-option-group vivid-store-col-2">
-                    <label class="option-group-label"><?php echo $optionGroup->getName()?></label>
-                    <select name="pog<?php echo $optionGroup->getID()?>">
-                        <?php
-                        foreach($optionItems as $option){
-                            if($option->getProductOptionGroupID()==$optionGroup->getID()){?>
-                                <option value="<?php echo $option->getID()?>"><?php echo $option->getName()?></option>
-                              <?php //echo '<input type="radio" name="pog'.$optionGroup->getID().'" value="'. $option->getID(). '" />' . $option->getName() . '<br />'; ?>
-                            <?php }
-                        }//foreach    
-                        ?>
-                    </select>
-                </div>
-                <?php } ?>
+
+                foreach($optionGroups as $optionGroup) {
+                    $groupoptions = array();
+                    foreach ($optionItems as $option) {
+                        if ($option->getProductOptionGroupID() == $optionGroup->getID()) {
+                            $groupoptions[] = $option;
+                        }
+                    }
+                    ?>
+                    <?php if (!empty($groupoptions)) { ?>
+                        <div class="product-option-group vivid-store-col-2">
+                            <label class="option-group-label"><?php echo $optionGroup->getName() ?></label>
+                            <select name="pog<?php echo $optionGroup->getID() ?>">
+                                <?php
+                                foreach ($groupoptions as $option) { ?>
+                                    <option value="<?php echo $option->getID() ?>"><?php echo $option->getName() ?></option>
+                                    <?php
+                                    // below is an example of a radio button, comment out the <select> and <option> tags to use instead
+                                    //echo '<input type="radio" name="pog'.$optionGroup->getID().'" value="'. $option->getID(). '" />' . $option->getName() . '<br />'; ?>
+                                <?php } ?>
+                            </select>
+                        </div>
+                    <?php }
+                }?>
             </div>
-            
+
             <?php if($showCartButton) {?>
             <div class="product-button-shell">
                 <input type="hidden" name="pID" value="<?php echo $product->getProductID()?>">
@@ -154,48 +160,47 @@ if(is_object($product)){?>
         gallery:{enabled:true}
     });
 
-    <?php if ($product->hasVariations()) {?>
+    <?php if ($product->hasVariations() && !empty($varationLookup)) {?>
 
-    <?php
-    $varationData = array();
-    foreach($variationLookup as $key=>$variation) {
-        $product->setVariation($variation);
+        <?php
+        $varationData = array();
+        foreach($variationLookup as $key=>$variation) {
+            $product->setVariation($variation);
 
-        $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(),'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
-    } ?>
+            $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(),'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
+        } ?>
 
-    $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input').change(function(){
-        var variationdata = <?php echo json_encode($varationData); ?>;
-        var ar = [];
+        $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input').change(function(){
+            var variationdata = <?php echo json_encode($varationData); ?>;
+            var ar = [];
 
-        $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input:checked').each(function(){
-            ar.push($(this).val());
-        })
+            $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input:checked').each(function(){
+                ar.push($(this).val());
+            })
 
-        ar.sort();
-        var pdb = $(this).closest('.product-detail-block');
+            ar.sort();
+            var pdb = $(this).closest('.product-detail-block');
 
 
+            if (variationdata[ar.join('_')]['saleprice']) {
+                var pricing =  '<span class="sale-price"><?php echo t("On Sale: "); ?>'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
+                    '<span class="original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
 
-        if (variationdata[ar.join('_')]['saleprice']) {
-            var pricing =  '<span class="sale-price"><?php echo t("On Sale: "); ?>'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
-                '<span class="original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
+                pdb.find('.product-price').html(pricing);
 
-            pdb.find('.product-price').html(pricing);
+            } else {
+                pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
+            }
 
-        } else {
-            pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
-        }
+            if (variationdata[ar.join('_')]['available']) {
+                pdb.find('.out-of-stock-label').addClass('hidden');
+                pdb.find('.btn-add-to-cart').removeClass('hidden');
+            } else {
+                pdb.find('.out-of-stock-label').removeClass('hidden');
+                pdb.find('.btn-add-to-cart').addClass('hidden');
+            }
 
-        if (variationdata[ar.join('_')]['available']) {
-            pdb.find('.out-of-stock-label').addClass('hidden');
-            pdb.find('.btn-add-to-cart').removeClass('hidden');
-        } else {
-            pdb.find('.out-of-stock-label').removeClass('hidden');
-            pdb.find('.btn-add-to-cart').addClass('hidden');
-        }
-
-    });
+        });
     <?php } ?>
 
 });

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -98,7 +98,7 @@ if(is_object($p)){?>
             </div>
             <?php } ?>
             
-            <div class="clearfix col-container product-options">
+            <div class="clearfix col-container product-options" id="product-options-<?php echo $bID; ?>">
                 <?php if ($p->allowQuantity()) { ?>
                 <div class="product-modal-option-group vivid-store-col-2">
                     <label class="option-group-label"><?=t('Quantity')?></label>
@@ -148,12 +148,35 @@ if(is_object($p)){?>
     </div>
     
 </form>
-<script type="text/javascript">
-$(function() {
+
+    <script type="text/javascript">
+    $(function() {
     $('.product-thumb').magnificPopup({
         type:'image',
         gallery:{enabled:true}
     });
+
+    <?php if ($p->hasVariations()) {?>
+
+    <?php
+    $varationData = array();
+    foreach($variationLookup as $key=>$variation) {
+        $varationData[$key] = array('price'=>$variation->getFormattedVariationPrice());
+    } ?>
+
+    $('#product-options-<?php echo $bID; ?> select').change(function(){
+        var variationdata = <?php echo json_encode($varationData); ?>;
+        var ar = [];
+
+        $('#product-options-<?php echo $bID; ?> select').each(function(){
+            ar.push($(this).val());
+        })
+
+        ar.sort();
+        $(this).closest('.product-detail-block').find('.product-price').html(variationdata[ar.join('_')]['price']);
+    });
+    <?php } ?>
+
 });
 </script>
    

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -130,11 +130,8 @@ if(is_object($p)){?>
             <?php if($showCartButton) {?>
             <div class="product-button-shell">
                 <input type="hidden" name="pID" value="<?=$p->getProductID()?>">
-                <?php if($p->isSellable()){?>
-                <a href="javascript:vividStore.addToCart(<?=$p->getProductID()?>,false)" class="btn btn-primary"><?= ($btnText ? h($btnText) : t("Add to Cart"))?></a>
-                <?php } else { ?>
-                    <span class="out-of-stock-label"><?=t("Out of Stock")?></span>
-                <?php } ?>
+                    <a href="javascript:vividStore.addToCart(<?=$p->getProductID()?>,false)" class="btn btn-primary add-to-cart-button <?php echo ($p->isSellable() ? '' : 'hidden');?> "><?= ($btnText ? h($btnText) : t("Add to Cart"))?></a>
+                    <span class="out-of-stock-label <?php echo ($p->isSellable() ? 'hidden' : '');?>"><?=t("Out of Stock")?></span>
             </div>
             <?php } ?>
             
@@ -161,7 +158,7 @@ if(is_object($p)){?>
     <?php
     $varationData = array();
     foreach($variationLookup as $key=>$variation) {
-        $varationData[$key] = array('price'=>$variation->getFormattedVariationPrice());
+        $varationData[$key] = array('price'=>$variation->getFormattedVariationPrice(), 'available'=>($variation->isSellable()));
     } ?>
 
     $('#product-options-<?php echo $bID; ?> select').change(function(){
@@ -173,7 +170,18 @@ if(is_object($p)){?>
         })
 
         ar.sort();
-        $(this).closest('.product-detail-block').find('.product-price').html(variationdata[ar.join('_')]['price']);
+        var pdb = $(this).closest('.product-detail-block');
+
+        pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
+
+        if (variationdata[ar.join('_')]['available']) {
+            pdb.find('.out-of-stock-label').addClass('hidden');
+            pdb.find('.add-to-cart-button').removeClass('hidden');
+        } else {
+            pdb.find('.out-of-stock-label').removeClass('hidden');
+            pdb.find('.add-to-cart-button').addClass('hidden');
+        }
+
     });
     <?php } ?>
 

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -167,7 +167,20 @@ if(is_object($product)){?>
         foreach($variationLookup as $key=>$variation) {
             $product->setVariation($variation);
 
-            $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(),'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
+            $imgObj = $variation->getVariationImageObj();
+
+            if ($imgObj) {
+                $thumb = Core::make('helper/image')->getThumbnail($imgObj,600,800,true);
+            }
+
+            $varationData[$key] = array(
+            'price'=>$product->getFormattedOriginalPrice(),
+            'saleprice'=>$product->getFormattedSalePrice(),
+            'available'=>($variation->isSellable()),
+            'imageThumb'=>$thumb ? $thumb->src : '',
+            'image'=>$imgObj ? $imgObj->getRelativePath() : ''
+
+            );
         } ?>
 
         $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input').change(function(){
@@ -196,6 +209,19 @@ if(is_object($product)){?>
             } else {
                 pdb.find('.out-of-stock-label').removeClass('hidden');
                 pdb.find('.btn-add-to-cart').addClass('hidden');
+            }
+
+            if (variationdata[ar.join('_')]['imageThumb']) {
+                var image = pdb.find('.product-primary-image img');
+
+                if (image) {
+                    image.attr('src', variationdata[ar.join('_')]['imageThumb']);
+                    var link = image.parent();
+
+                    if (link) {
+                        link.attr('href', variationdata[ar.join('_')]['image'])
+                    }
+                }
             }
 
         });

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -160,7 +160,7 @@ if(is_object($product)){?>
         gallery:{enabled:true}
     });
 
-    <?php if ($product->hasVariations() && !empty($varationLookup)) {?>
+    <?php if ($product->hasVariations() && !empty($variationLookup)) {?>
 
         <?php
         $varationData = array();
@@ -181,13 +181,11 @@ if(is_object($product)){?>
             ar.sort();
             var pdb = $(this).closest('.product-detail-block');
 
-
             if (variationdata[ar.join('_')]['saleprice']) {
                 var pricing =  '<span class="sale-price"><?php echo t("On Sale: "); ?>'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
                     '<span class="original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
 
                 pdb.find('.product-price').html(pricing);
-
             } else {
                 pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
             }

--- a/blocks/vivid_product/view.php
+++ b/blocks/vivid_product/view.php
@@ -1,27 +1,27 @@
 <?php
 defined('C5_EXECUTE') or die(_("Access Denied."));
 
-if(is_object($p)){?>
+if(is_object($product)){?>
 
-<form class="product-detail-block" id="form-add-to-cart-<?=$p->getProductID()?>">
+<form class="product-detail-block" id="form-add-to-cart-<?php echo $product->getProductID()?>">
     
     <div class="col-container">
         <?php if($showImage){ ?>
         <div class="vivid-store-col-2 product-image">
             <?php
-                $imgObj = $p->getProductImageObj();
+                $imgObj = $product->getProductImageObj();
                 if(is_object($imgObj)){
                     $thumb = Core::make('helper/image')->getThumbnail($imgObj,600,800,true);
             ?>
             <div class="product-primary-image">
-                <a href="<?=$imgObj->getRelativePath()?>" class="product-thumb">
-                    <img src="<?=$thumb->src?>">
+                <a href="<?php echo $imgObj->getRelativePath()?>" class="product-thumb">
+                    <img src="<?php echo $thumb->src?>">
                 </a>
             </div>
             <?php } ?>
 
             <?php
-            $images = $p->getProductImagesObjects();
+            $images = $product->getProductImagesObjects();
             if(count($images)>0){
                 echo '<div class="product-additional-images">';
                 foreach($images as $secondaryimage) {
@@ -29,7 +29,7 @@ if(is_object($p)){?>
                          $thumb = Core::make('helper/image')->getThumbnail($secondaryimage, 300, 300, true);
                       ?>
                       
-                      <a class="product-thumb" href="<?=$secondaryimage->getRelativePath()?>"><img src="<?=$thumb->src?>"></a>
+                      <a class="product-thumb" href="<?php echo $secondaryimage->getRelativePath()?>"><img src="<?php echo $thumb->src?>"></a>
                       
                     <?php }
                 }
@@ -45,32 +45,32 @@ if(is_object($p)){?>
             <?php if($showGroups){?>
                 <ul>
                 <?php
-                $productgroups = $p->getProductGroups();
+                $productgroups = $product->getProductGroups();
                 foreach($productgroups as $pg) { ?>
-                    <li class="product-group"><?= $pg->gName;?> </li>
+                    <li class="product-group"><?php echo  $pg->gName;?> </li>
                 <?php } ?>
                 </ul>
             <?php } ?>
             
             <?php if($showIsFeatured){
-               if($p->isFeatured()){?> 
-                <span class="product-featured"><?=t("Featured Item")?></span>
+               if($product->isFeatured()){?> 
+                <span class="product-featured"><?php echo t("Featured Item")?></span>
                <?php }
             }?>
             
             <?php if($showProductName){?>
-            <h1 class="product-name"><?=$p->getProductName()?></h1>
+            <h1 class="product-name"><?php echo $product->getProductName()?></h1>
             <?php } ?>
             
             <?php if($showProductPrice){?>
             <span class="product-price">
                 <?php
-                    $salePrice = $p->getProductSalePrice();
+                    $salePrice = $product->getProductSalePrice();
                     if(isset($salePrice) && $salePrice != ""){
-                        echo '<span class="sale-price">'.t("On Sale: ").$p->getFormattedSalePrice().'</span>';
-                        echo '<span class="original-price">'.$p->getFormattedPrice().'</span>';
+                        echo '<span class="sale-price">'.t("On Sale: ").$product->getFormattedSalePrice().'</span>';
+                        echo '<span class="original-price">'.$product->getFormattedOriginalPrice().'</span>';
                     } else {
-                        echo $p->getFormattedPrice();
+                        echo $product->getFormattedPrice();
                     }
                 ?>
             </span>
@@ -78,47 +78,48 @@ if(is_object($p)){?>
             
             <?php if($showProductDescription){?>
             <div class="product-description">
-                <?=$p->getProductDesc()?>
+                <?php echo $product->getProductDesc()?>
             </div>
             <?php } ?>
             
             <?php if($showDimensions){?>
             <div class="product-dimensions">
-                <strong><?=t("Dimensions")?>:</strong>
-                <?=$p->getDimensions()?>
+                <strong><?php echo t("Dimensions")?>:</strong>
+                <?php echo $product->getDimensions()?>
                 <?php echo Config::get('vividstore.sizeUnit'); ?>
             </div>
             <?php } ?>
             
             <?php if($showWeight){?>
             <div class="product-weight">
-                <strong><?=t("Weight")?>:</strong>
-                <?=$p->getProductWeight()?>
+                <strong><?php echo t("Weight")?>:</strong>
+                <?php echo $product->getProductWeight()?>
                 <?php echo Config::get('vividstore.weightUnit'); ?>
             </div>
             <?php } ?>
             
             <div class="clearfix col-container product-options" id="product-options-<?php echo $bID; ?>">
-                <?php if ($p->allowQuantity()) { ?>
+                <?php if ($product->allowQuantity()) { ?>
                 <div class="product-modal-option-group vivid-store-col-2">
-                    <label class="option-group-label"><?=t('Quantity')?></label>
-                    <input type="number" name="quantity" class="product-qty" value="1" min="1" step="1" <?=($p->allowBackOrders() ? '' :'max="' . $p->getProductQty() . '"' );?>>
+                    <label class="option-group-label"><?php echo t('Quantity')?></label>
+                    <input type="number" name="quantity" class="product-qty" value="1" min="1" step="1" <?php echo ($product->allowBackOrders() ? '' :'max="' . $product->getProductQty() . '"' );?>>
                 </div>
                     <?php } else { ?>
                     <input type="hidden" name="quantity" class="product-qty" value="1">
                 <?php } ?>
                 <?php
-                $optionGroups = $p->getProductOptionGroups();
-                $optionItems = $p->getProductOptionItems();
+                $optionGroups = $product->getProductOptionGroups();
+                $optionItems = $product->getProductOptionItems();
                 foreach($optionGroups as $optionGroup){
                 ?>
                 <div class="product-option-group vivid-store-col-2">
-                    <label class="option-group-label"><?=$optionGroup->getName()?></label>
-                    <select name="pog<?=$optionGroup->getID()?>">
+                    <label class="option-group-label"><?php echo $optionGroup->getName()?></label>
+                    <select name="pog<?php echo $optionGroup->getID()?>">
                         <?php
                         foreach($optionItems as $option){
                             if($option->getProductOptionGroupID()==$optionGroup->getID()){?>
-                                <option value="<?=$option->getID()?>"><?=$option->getName()?></option>
+                                <option value="<?php echo $option->getID()?>"><?php echo $option->getName()?></option>
+                              <?php //echo '<input type="radio" name="pog'.$optionGroup->getID().'" value="'. $option->getID(). '" />' . $option->getName() . '<br />'; ?>
                             <?php }
                         }//foreach    
                         ?>
@@ -129,17 +130,17 @@ if(is_object($p)){?>
             
             <?php if($showCartButton) {?>
             <div class="product-button-shell">
-                <input type="hidden" name="pID" value="<?=$p->getProductID()?>">
-                    <a href="javascript:vividStore.addToCart(<?=$p->getProductID()?>,false)" class="btn btn-primary add-to-cart-button <?php echo ($p->isSellable() ? '' : 'hidden');?> "><?= ($btnText ? h($btnText) : t("Add to Cart"))?></a>
-                    <span class="out-of-stock-label <?php echo ($p->isSellable() ? 'hidden' : '');?>"><?=t("Out of Stock")?></span>
+                <input type="hidden" name="pID" value="<?php echo $product->getProductID()?>">
+                    <a href="javascript:vividStore.addToCart(<?php echo $product->getProductID()?>,false)" class="btn btn-primary btn-add-to-cart <?php echo ($product->isSellable() ? '' : 'hidden');?> "><?php echo  ($btnText ? h($btnText) : t("Add to Cart"))?></a>
+                    <span class="out-of-stock-label <?php echo ($product->isSellable() ? 'hidden' : '');?>"><?php echo t("Out of Stock")?></span>
             </div>
             <?php } ?>
             
         </div>
         <?php if($showProductDetails){?>
         <div class="vivid-store-col-1 product-detailed-description">
-            <h2><?=t("Product Details")?></h2>
-            <?=$p->getProductDetail()?>
+            <h2><?php echo t("Product Details")?></h2>
+            <?php echo $product->getProductDetail()?>
         </div>
         <?php } ?>
     </div>
@@ -153,33 +154,45 @@ if(is_object($p)){?>
         gallery:{enabled:true}
     });
 
-    <?php if ($p->hasVariations()) {?>
+    <?php if ($product->hasVariations()) {?>
 
     <?php
     $varationData = array();
     foreach($variationLookup as $key=>$variation) {
-        $varationData[$key] = array('price'=>$variation->getFormattedVariationPrice(), 'available'=>($variation->isSellable()));
+        $product->setVariation($variation);
+
+        $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(),'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
     } ?>
 
-    $('#product-options-<?php echo $bID; ?> select').change(function(){
+    $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input').change(function(){
         var variationdata = <?php echo json_encode($varationData); ?>;
         var ar = [];
 
-        $('#product-options-<?php echo $bID; ?> select').each(function(){
+        $('#product-options-<?php echo $bID; ?> select, #product-options-<?php echo $bID; ?> input:checked').each(function(){
             ar.push($(this).val());
         })
 
         ar.sort();
         var pdb = $(this).closest('.product-detail-block');
 
-        pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
+
+
+        if (variationdata[ar.join('_')]['saleprice']) {
+            var pricing =  '<span class="sale-price"><?php echo t("On Sale: "); ?>'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
+                '<span class="original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
+
+            pdb.find('.product-price').html(pricing);
+
+        } else {
+            pdb.find('.product-price').html(variationdata[ar.join('_')]['price']);
+        }
 
         if (variationdata[ar.join('_')]['available']) {
             pdb.find('.out-of-stock-label').addClass('hidden');
-            pdb.find('.add-to-cart-button').removeClass('hidden');
+            pdb.find('.btn-add-to-cart').removeClass('hidden');
         } else {
             pdb.find('.out-of-stock-label').removeClass('hidden');
-            pdb.find('.add-to-cart-button').addClass('hidden');
+            pdb.find('.btn-add-to-cart').addClass('hidden');
         }
 
     });
@@ -189,5 +202,5 @@ if(is_object($p)){?>
 </script>
    
 <?php } else { ?>
-    <div class="alert alert-info"><?=t("We can't seem to find this product at the moment")?></div>
+    <div class="alert alert-info"><?php echo t("We can't seem to find this product at the moment")?></div>
 <?php } ?>

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -8,6 +8,7 @@ use Page;
 use Database;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductList as StoreProductList;
 use \Concrete\Package\VividStore\Src\VividStore\Group\GroupList as StoreGroupList;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation as StoreProductVariation;
 
 
 class Controller extends BlockController
@@ -101,7 +102,13 @@ class Controller extends BlockController
         $products->setGroupMatchAny($this->groupMatchAny);
         $paginator = $products->getPagination();
         $pagination = $paginator->renderDefaultView();
-        $this->set('products',$paginator->getCurrentPageResults());
+        $products = $paginator->getCurrentPageResults();
+
+        foreach($products as $product) {
+            $product->setInitialVariation();
+        }
+
+        $this->set('products', $products);
         $this->set('pagination',$pagination);
         $this->set('paginator', $paginator);
 

--- a/blocks/vivid_product_list/controller.php
+++ b/blocks/vivid_product_list/controller.php
@@ -9,6 +9,7 @@ use Database;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductList as StoreProductList;
 use \Concrete\Package\VividStore\Src\VividStore\Group\GroupList as StoreGroupList;
 
+
 class Controller extends BlockController
 {
     protected $btTable = 'btVividStoreProductList';

--- a/blocks/vivid_product_list/view.php
+++ b/blocks/vivid_product_list/view.php
@@ -113,7 +113,20 @@ if($products){
                     $varationData = array();
                     foreach($variationLookup as $key=>$variation) {
                         $product->setVariation($variation);
-                        $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(), 'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
+
+                        $imgObj = $variation->getVariationImageObj();
+
+                        if ($imgObj) {
+                            $thumb = Core::make('helper/image')->getThumbnail($imgObj,400,280,true);
+                        }
+
+                        $varationData[$key] = array(
+                        'price'=>$product->getFormattedOriginalPrice(),
+                        'saleprice'=>$product->getFormattedSalePrice(),
+                        'available'=>($variation->isSellable()),
+                        'imageThumb'=>$thumb ? $thumb->src : '',
+                        'image'=>$imgObj ? $imgObj->getRelativePath() : '');
+
                     } ?>
 
 
@@ -145,6 +158,14 @@ if($products){
                         } else {
                             pli.find('.out-of-stock-label').removeClass('hidden');
                             pli.find('.btn-add-to-cart').addClass('hidden');
+                        }
+
+                        if (variationdata[ar.join('_')]['imageThumb']) {
+                            var image = pli.find('.product-list-thumbnail img');
+
+                            if (image) {
+                                image.attr('src', variationdata[ar.join('_')]['imageThumb']);
+                            }
                         }
 
                     });

--- a/blocks/vivid_product_list/view.php
+++ b/blocks/vivid_product_list/view.php
@@ -7,6 +7,9 @@ if($products){
     $i=1;
     foreach($products as $product){
 
+        $optionGroups = $product->getProductOptionGroups();
+        $optionItems = $product->getProductOptionItems();
+
         if ($product->hasVariations()) {
             $variations = StoreProductVariation::getVariationsForProduct($product);
 
@@ -18,11 +21,8 @@ if($products){
                     $ids = $variation->getOptionItemIDs();
                     $variationLookup[implode('_', $ids)] = $variation;
                 }
-
-                $product->setVariation($variations[0]);
             }
         }
-
 
         //this is done so we can get a type of active class if there's a product list on the product page
         $class = "product-list-item vivid-store-col-".$productsPerRow;
@@ -31,9 +31,9 @@ if($products){
         }
     ?>
     
-        <div class="<?=$class?>">
+        <div class="<?php echo $class?>">
             
-            <form class="product-list-item-inner" id="form-add-to-cart-<?=$product->getProductID()?>">
+            <form class="product-list-item-inner" id="form-add-to-cart-list-<?php echo $product->getProductID()?>">
                 
                 <?php 
                     $imgObj = $product->getProductImageObj();
@@ -41,53 +41,52 @@ if($products){
                         $thumb = $ih->getThumbnail($imgObj,400,280,true);?>
                         <div class="product-list-thumbnail">
                             <?php if($showQuickViewLink){ ?>
-                            <a class="product-quick-view" href="javascript:vividStore.productModal(<?=$product->getProductID()?>);">
-                                <?=t("Quick View")?>
+                            <a class="product-quick-view" href="javascript:vividStore.productModal(<?php echo $product->getProductID()?>);">
+                                <?php echo t("Quick View")?>
                             </a>
                             <?php } ?>
-                            <img src="<?=$thumb->src?>" class="img-responsive">
+                            <img src="<?php echo $thumb->src?>" class="img-responsive">
                         </div>
                 <?php
                     }// if is_obj
                 ?>
-                <h2 class="product-list-name"><?=$product->getProductName()?></h2>
+                <h2 class="product-list-name"><?php echo $product->getProductName()?></h2>
                 <span class="product-list-price">
                     <?php
                         $salePrice = $product->getProductSalePrice();
                         if(isset($salePrice) && $salePrice != ""){
                             echo '<span class="sale-price">'.$product->getFormattedSalePrice().'</span>';
-                            echo '<span class="original-price">'.$product->getFormattedPrice().'</span>';
+                            echo '<span class="original-price">'.$product->getFormattedOriginalPrice().'</span>';
                         } else {
                             echo $product->getFormattedPrice();
                         }
                     ?>
                 </span>
                 <?php if($showDescription){ ?>
-                <div class="product-list-description"><?=$product->getProductDesc()?></div>
+                <div class="product-list-description"><?php echo $product->getProductDesc()?></div>
                 <?php } ?>
                 <?php if($showPageLink){?>
-                <a href="<?=URL::page(Page::getByID($product->getProductPageID()))?>" class="btn btn-default btn-sm btn-more-details"><?=t("More Details")?></a>
+                <a href="<?php echo URL::page(Page::getByID($product->getProductPageID()))?>" class="btn btn-default btn-sm btn-more-details"><?php echo t("More Details")?></a>
                 <?php } ?>
                 <?php if($showAddToCart){
                     /*
                      * If we have an add to cart button, 
                      * we at least need to have the Product ID
-                     * and a default quanity (1)
+                     * and a default quantity (1)
                      */
                 ?>
 
                 <?php
-                $optionGroups = $product->getProductOptionGroups();
-                $optionItems = $product->getProductOptionItems();
+
                 foreach($optionGroups as $optionGroup){
                     ?>
                     <div class="product-option-group">
-                        <label class="option-group-label"><?=$optionGroup->getName()?></label>
-                        <select name="pog<?=$optionGroup->getID()?>">
+                        <label class="option-group-label"><?php echo $optionGroup->getName()?></label>
+                        <select name="pog<?php echo $optionGroup->getID()?>">
                             <?php
                             foreach($optionItems as $option){
                                 if($option->getProductOptionGroupID()==$optionGroup->getID()){?>
-                                    <option value="<?=$option->getID()?>"><?=$option->getName()?></option>
+                                    <option value="<?php echo $option->getID()?>"><?php echo $option->getName()?></option>
                                 <?php }
                             }//foreach
                             ?>
@@ -95,17 +94,13 @@ if($products){
                     </div>
                 <?php } ?>
 
-                <input type="hidden" name="pID" value="<?=$product->getProductID()?>">
+                <input type="hidden" name="pID" value="<?php echo $product->getProductID()?>">
                 <input type="hidden" name="quantity" class="product-qty" value="1">
-                <?php if($product->isSellable()){?>
-                <a href="javascript:vividStore.addToCart(<?=$product->getProductID()?>,false)" class="btn btn-primary btn-sm btn-add-to-cart"><?=t("Add to Cart")?></a>
-                <?php } else { ?>
-                    <span class="out-of-stock-label"><?=t("Out of Stock")?></span>
-                <?php } ?>
+                <a href="javascript:vividStore.addToCart(<?php echo $product->getProductID()?>,'list')" class="btn btn-primary btn-add-to-cart <?php echo ($product->isSellable() ? '' : 'hidden');?> "><?php echo  ($btnText ? h($btnText) : t("Add to Cart"))?></a>
+                <span class="out-of-stock-label <?php echo ($product->isSellable() ? 'hidden' : '');?>"><?php echo t("Out of Stock")?></span>
+
                 <?php } ?>
 
-
-            
             </form><!-- .product-list-item-inner -->
             
         </div><!-- .product-list-item -->
@@ -117,19 +112,41 @@ if($products){
                     <?php
                     $varationData = array();
                     foreach($variationLookup as $key=>$variation) {
-                        $varationData[$key] = array('price'=>$variation->getFormattedVariationPrice());
+                        $product->setVariation($variation);
+                        $varationData[$key] = array('price'=>$product->getFormattedOriginalPrice(), 'saleprice'=>$product->getFormattedSalePrice(), 'available'=>($variation->isSellable()));
                     } ?>
 
-                    $('.product-list #form-add-to-cart-<?=$product->getProductID()?> select').change(function(){
-                    var variationdata = <?php echo json_encode($varationData); ?>;
-                    var ar = [];
+                    $('.product-list #form-add-to-cart-list-<?php echo $product->getProductID()?> select').change(function(){
+                        var variationdata = <?php echo json_encode($varationData); ?>;
+                        var ar = [];
 
-                    $('.product-list #form-add-to-cart-<?=$product->getProductID()?> select').each(function(){
-                        ar.push($(this).val());
-                    })
+                        $('.product-list #form-add-to-cart-list-<?php echo $product->getProductID()?> select').each(function(){
+                            ar.push($(this).val());
+                        })
 
-                    ar.sort();
-                    $(this).closest('.product-list-item-inner').find('.product-list-price').html(variationdata[ar.join('_')]['price']);
+                        ar.sort();
+
+                        var pli = $(this).closest('.product-list-item-inner');
+
+
+                        if (variationdata[ar.join('_')]['saleprice']) {
+                            var pricing =  '<span class="sale-price">'+ variationdata[ar.join('_')]['saleprice']+'</span>' +
+                                '<span class="original-price">' + variationdata[ar.join('_')]['price'] +'</span>';
+
+                            pli.find('.product-list-price').html(pricing);
+
+                        } else {
+                            pli.find('.product-list-price').html(variationdata[ar.join('_')]['price']);
+                        }
+
+                        if (variationdata[ar.join('_')]['available']) {
+                            pli.find('.out-of-stock-label').addClass('hidden');
+                            pli.find('.btn-add-to-cart').removeClass('hidden');
+                        } else {
+                            pli.find('.out-of-stock-label').removeClass('hidden');
+                            pli.find('.btn-add-to-cart').addClass('hidden');
+                        }
+
                     });
                 });
             </script>
@@ -155,5 +172,5 @@ if($products){
     
 } //if products
 else { ?>
-    <div class="alert alert-info"><?=t("No Products Available")?></div>
+    <div class="alert alert-info"><?php echo t("No Products Available")?></div>
 <?php } ?>

--- a/controller.php
+++ b/controller.php
@@ -14,7 +14,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'vivid_store';
     protected $appVersionRequired = '5.7.3';
-    protected $pkgVersion = '3.0.1';
+    protected $pkgVersion = '3.0.1.4';
     protected $pkgAutoloaderRegistries = array(
         'src/AuthorizeNet' => '\AuthorizeNet',
         'src/Omnipay' => '\Omnipay'

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -96,8 +96,16 @@ class Products extends DashboardPageController
         $this->set('pageTitle', t('Add Product'));
         $this->set('usergroups', $usergrouparray);
     }
-    public function edit($pID)
+    public function edit($pID, $status = '')
     {
+        if ($status == 'updated') {
+            $this->set("success",t("Product Updated"));
+        }
+
+        if ($status == 'added') {
+            $this->set("success",t("Product Added"));
+        }
+
         $this->loadFormAssets();
         $this->set("actionType",t("Update"));
         
@@ -138,7 +146,7 @@ class Products extends DashboardPageController
         $this->set('groupLookup', $groupLookup);
 
         $optionArrays = array_values($optionArrays);
-        $comboOptions = $this->combinations($optionArrays);
+        $comboOptions = StoreProductVariation::combinations($optionArrays);
 
         $checkedOptions = array();
 
@@ -197,32 +205,6 @@ class Products extends DashboardPageController
         $this->set('pageTitle', t('Edit Product'));
         $this->set('usergroups', $usergrouparray);
     }
-
-    private function combinations($arrays, $i = 0) {
-        if (!isset($arrays[$i])) {
-            return array();
-        }
-        if ($i == count($arrays) - 1) {
-            return $arrays[$i];
-        }
-
-        // get combinations from subsequent arrays
-        $tmp = $this->combinations($arrays, $i + 1);
-
-        $result = array();
-
-        // concat each array from tmp with each element from $arrays[$i]
-        foreach ($arrays[$i] as $v) {
-            foreach ($tmp as $t) {
-                $result[] = is_array($t) ?
-                    array_merge(array($v), $t) :
-                    array($v, $t);
-            }
-        }
-
-        return $result;
-    }
-
 
 
     public function generate($pID,$templateID=null)
@@ -310,9 +292,9 @@ class Products extends DashboardPageController
 
 
                 if($data['pID']){
-                    $this->redirect('/dashboard/store/products/', 'updated');
+                    $this->redirect('/dashboard/store/products/edit/' . $product->getProductID(), 'updated');
                 } else {
-                    $this->redirect('/dashboard/store/products/', 'success');
+                    $this->redirect('/dashboard/store/products/edit/' . $product->getProductID(), 'success');
                 }
             }//if no errors
         }//if post

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -129,8 +129,6 @@ class Products extends DashboardPageController
             $optionItemLookup[ $optItem->getID()] = $optItem;
         }
 
-
-
         $groupLookup = array();
 
         foreach($groups as $group) {
@@ -141,6 +139,18 @@ class Products extends DashboardPageController
 
         $optionArrays = array_values($optionArrays);
         $comboOptions = $this->combinations($optionArrays);
+
+        $checkedOptions = array();
+
+        foreach($comboOptions as $option) {
+            if (!is_array($option)) {
+                $checkedOptions[] = array($option);
+            } else {
+                $checkedOptions[] =$option;
+            }
+        }
+
+        $comboOptions = $checkedOptions;
 
         $this->set('comboOptions', $comboOptions);
         $this->set('optionItemLookup', $optionItemLookup);

--- a/db.xml
+++ b/db.xml
@@ -30,6 +30,7 @@
         <field name="pID" type="I"></field>
         <field name="oID" type="I"></field>
         <field name="oiProductName" type="C" size="255"></field>
+        <field name="oiSKU" type="C" size="255"></field>
         <field name="oiPricePaid" type="N" size="10.4"></field>
         <field name="oiTax" type="C" size="255"></field>
         <field name="oiTaxIncluded" type="C" size="255"></field>

--- a/elements/cart_list.php
+++ b/elements/cart_list.php
@@ -13,6 +13,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOpt
             $pID = $cartItem['product']['pID'];
             $qty = $cartItem['product']['qty'];
             $product = StoreProduct::getByID($pID);
+
+            if ($cartItem['product']['variation']) {
+                $product->setVariation($cartItem['product']['variation']);
+            }
+
             if($i%2==0){$classes=" striped"; }else{ $classes=""; }
             if(is_object($product)){
                 ?>

--- a/elements/cart_modal.php
+++ b/elements/cart_modal.php
@@ -44,6 +44,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOpt
                     $pID = $cartItem['product']['pID'];
                     $qty = $cartItem['product']['qty'];
                     $product = StoreProduct::getByID($pID);
+
+                    if ($cartItem['product']['variation']) {
+                        $product->setVariation($cartItem['product']['variation']);
+                    }
+
                     if($i%2==0){$classes=" striped"; }else{ $classes=""; }
                     if(is_object($product)){
                         ?>

--- a/elements/product_modal.php
+++ b/elements/product_modal.php
@@ -42,7 +42,7 @@
         <input type="hidden" name="pID" value="<?=$product->getProductID()?>">
         <div class="product-modal-buttons">
             <?php if($product->isSellable()){?>
-            <a href="javascript:vividStore.addToCart(<?=$product->getProductID()?>,true)"><?=t("Add to Cart")?></a>
+            <a href="javascript:vividStore.addToCart(<?=$product->getProductID()?>,'modal')"><?=t("Add to Cart")?></a>
             <?php } else {?>
                 <span class="out-of-stock-label"><?=t("Out of Stock")?></span>
             <?php } ?>

--- a/js/vivid-store.js
+++ b/js/vivid-store.js
@@ -61,11 +61,14 @@ exitModal: function(){
     },
 
 
+
     //Add Item to Cart
-    addToCart: function(pID, modal){
+    addToCart: function(pID, type){
         var form;
-        if(modal==true){
+        if(type =='modal'){
             form = $('#form-add-to-cart-modal-'+pID);
+        } else if (type == 'list') {
+            form = $('#form-add-to-cart-list-'+pID);
         } else {
             form = $('#form-add-to-cart-'+pID);
         }

--- a/mail/order_receipt.php
+++ b/mail/order_receipt.php
@@ -68,7 +68,11 @@ ob_start();
                             foreach($items as $item){
                       ?>
                         <tr>
-                            <td><?=$item->getProductName()?></td>
+                            <td><?=$item->getProductName()?>
+                                <?php if ($sku = $item->getSKU()) {
+                                    echo '(' .  $sku . ')';
+                                } ?>
+                            </td>
                             <td>
                                 <?php
                                     $options = $item->getProductOptions();

--- a/single_pages/cart.php
+++ b/single_pages/cart.php
@@ -37,6 +37,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOpt
             $pID = $cartItem['product']['pID'];
             $qty = $cartItem['product']['qty'];
             $product = StoreProduct::getByID($pID);
+
+            if ($cartItem['product']['variation']) {
+                $product->setVariation($cartItem['product']['variation']);
+            }
+
             if($i%2==0){$classes=" striped"; }else{ $classes=""; }
             if(is_object($product)){
     ?>

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -81,7 +81,11 @@ use \Concrete\Package\VividStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKe
                     foreach($items as $item){
               ?>
                 <tr>
-                    <td><?=$item->getProductName()?></td>
+                    <td><?=$item->getProductName()?>
+                    <?php if ($sku = $item->getSKU()) {
+                    echo '(' .  $sku . ')';
+                     } ?>
+                    </td>
                     <td>
                         <?php
                             $options = $item->getProductOptions();

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -622,6 +622,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 </script>
 
             <br />
+
+            <div class="form-group" id="pVariations">
+                <?php echo $form->checkbox('pVariations', '1', $p->hasVariations())?>
+                <?php echo $form->label('pVariations', t('Options have different prices, SKUs or stock levels'))?>
+            </div>
+
             <h4><?php echo t('Variations');?></h4>
 
             <table class="table table-bordered">
@@ -643,8 +649,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                                     $comboIDs[] =  $optionItemID;
                                     sort($comboIDs);
 
-                                    echo '<span class="label label-primary">' .  $groupLookup[$optionItemLookup[$optionItemID]->getProductOptionGroupID()]->getName() . ': '.  $optionItemLookup[$optionItemID]->getName() . '</span><br />';
-                                }?>
+                                    $group = $groupLookup[$optionItemLookup[$optionItemID]->getProductOptionGroupID()];
+
+                                    echo '<span class="label label-primary">' . ($group ? $group->getName() : '') . ': '.  $optionItemLookup[$optionItemID]->getName() . '</span><br />';
+                                }
+
+                                ?>
 
                                 <input type="hidden" name="option_combo[]" value="<?php echo implode('_', $comboIDs);?>" />
 

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -28,28 +28,28 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
         <script type="text/javascript">
         $(function(){
             $('#delete').submit(function() {
-                return confirm('<?= t("Are you sure you want to delete this product?"); ?>');
+                return confirm('<?php echo  t("Are you sure you want to delete this product?"); ?>');
             });
         });
         </script>
     </div>
     <?php } ?>
 
-    <form method="post" action="<?=$view->action('save')?>">
-        <input type="hidden" name="pID" value="<?=$p->getProductID()?>"/>
+    <form method="post" action="<?php echo $view->action('save')?>">
+        <input type="hidden" name="pID" value="<?php echo $p->getProductID()?>"/>
 
         <div class="row">
             <div class="col-sm-4">
                 <div class="vivid-store-side-panel">
                     <ul>
-                        <li><a href="#product-overview" data-pane-toggle class="active"><?=t('Overview')?></a></li>
-                        <li><a href="#product-categories" data-pane-toggle><?=t('Categories')?></a></li>
-                        <li><a href="#product-shipping" data-pane-toggle><?=t('Shipping')?></a></li>
-                        <li><a href="#product-images" data-pane-toggle><?=t('Images')?></a></li>
-                        <li><a href="#product-options" data-pane-toggle><?=t('Options')?></a></li>
-                        <li><a href="#product-attributes" data-pane-toggle><?=t('Attributes')?></a></li>
-                        <li><a href="#product-digital" data-pane-toggle><?=t("Memberships and Downloads")?></a></li>
-                        <li><a href="#product-page" data-pane-toggle><?=t('Detail Page')?></a></li>
+                        <li><a href="#product-overview" data-pane-toggle class="active"><?php echo t('Overview')?></a></li>
+                        <li><a href="#product-categories" data-pane-toggle><?php echo t('Categories')?></a></li>
+                        <li><a href="#product-shipping" data-pane-toggle><?php echo t('Shipping')?></a></li>
+                        <li><a href="#product-images" data-pane-toggle><?php echo t('Images')?></a></li>
+                        <li><a href="#product-options" data-pane-toggle><?php echo t('Options')?></a></li>
+                        <li><a href="#product-attributes" data-pane-toggle><?php echo t('Attributes')?></a></li>
+                        <li><a href="#product-digital" data-pane-toggle><?php echo t("Memberships and Downloads")?></a></li>
+                        <li><a href="#product-page" data-pane-toggle><?php echo t('Detail Page')?></a></li>
                     </ul>
                 </div>
             </div>
@@ -91,7 +91,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <?php echo $form->label("pPrice", t("Price"));?>
                             <div class="input-group">
                                 <div class="input-group-addon">
-                                    <?= Config::get('vividstore.symbol');?>
+                                    <?php echo  Config::get('vividstore.symbol');?>
                                 </div>
                                 <?php $price = $p->getProductPrice(); ?>
                                 <?php echo $form->text("pPrice", $price?$price:'0');?>
@@ -103,7 +103,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <?php echo $form->label("pSalePrice", t("Sale Price"));?>
                             <div class="input-group">
                                 <div class="input-group-addon">
-                                    <?= Config::get('vividstore.symbol');?>
+                                    <?php echo  Config::get('vividstore.symbol');?>
                                 </div>
                                 <?php $salePrice = $p->getProductSalePrice(); ?>
                                 <?php echo $form->text("pSalePrice", $salePrice, array('placeholder'=>'No Sale Price Set'));?>
@@ -161,7 +161,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             </div>
 
                         </div>
-                        <div class="form-group" id="backorders" <?= ($p->isUnlimited() ? 'style="display: none"' : '');?>>
+                        <div class="form-group" id="backorders" <?php echo  ($p->isUnlimited() ? 'style="display: none"' : '');?>>
                             <?php echo $form->checkbox('pBackOrder', '1', $p->pBackOrder)?>
                             <?php echo $form->label('pBackOrder', t('Allow Back Orders'))?>
                         </div>
@@ -176,7 +176,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 </div>
                 <div class="form-group">
                     <?php echo $form->label("pDesc", t("Short Description"));?><br>
-                    <textarea class="redactor-content" name="pDesc" id="pDesc" style="display:none;"><?=$p->getProductDesc()?></textarea>
+                    <textarea class="redactor-content" name="pDesc" id="pDesc" style="display:none;"><?php echo $p->getProductDesc()?></textarea>
                     <script type="text/javascript">
                         $(function(){
                             $('#pDesc').redactor({
@@ -193,7 +193,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
                 <div class="form-group">
                     <?php echo $form->label("pDesc", t("Product Details (Long Description)"));?><br>
-                    <textarea class="redactor-content" name="pDetail" id="pDetail" style="display:none;"><?=$p->getProductDetail()?></textarea>
+                    <textarea class="redactor-content" name="pDetail" id="pDetail" style="display:none;"><?php echo $p->getProductDetail()?></textarea>
                     <script type="text/javascript">
                         $(function(){
                             $('#pDetail').redactor({
@@ -212,7 +212,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             </div><!-- #product-overview -->
 
             <div class="col-sm-7 store-pane" id="product-categories">
-                <h4><?=t('Categorized under pages')?></h4>
+                <h4><?php echo t('Categorized under pages')?></h4>
 
                 <div class="form-group" id="page_pickers">
                     <div class="page_picker">
@@ -220,14 +220,14 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     </div>
 
                     <?php for($i = 1; $i < 7; $i++) { ?>
-                        <div class="page_picker <?= ($locationPages[$i - 1] && $locationPages[$i - 1]->getCollectionID() ? '' : 'picker_hidden' ); ?>">
+                        <div class="page_picker <?php echo  ($locationPages[$i - 1] && $locationPages[$i - 1]->getCollectionID() ? '' : 'picker_hidden' ); ?>">
                             <?php echo $ps->selectPage('cID[]',  ($locationPages[$i] && $locationPages[$i]->getCollectionID()) ?  $locationPages[$i]->getCollectionID() : false); ?>
                         </div>
 
                     <?php } ?>
                 </div>
 
-                <h4><?=t('In product groups')?></h4>
+                <h4><?php echo t('In product groups')?></h4>
                 <div class="ccm-search-field-content ccm-search-field-content-select2">
                     <select multiple="multiple" name="pProductGroups[]" class="existing-select2 select2-select" style="width: 100%">
                         <?php
@@ -281,7 +281,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 </div>
                 
                 <div class="alert alert-info">
-                    <?=t("Keep in mind that the following information is not for the product itself, but for the shipping dimensions and weight")?>
+                    <?php echo t("Keep in mind that the following information is not for the product itself, but for the shipping dimensions and weight")?>
                 </div>
 
                 <div class="row">
@@ -290,8 +290,8 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <?php echo $form->label("pWeight", t("Weight"));?>
                             <div class="input-group" >
                                 <?php $weight = $p->getProductWeight(); ?>
-                                <?=$form->text('pWeight',$weight?$weight:'0')?>
-                                <div class="input-group-addon"><?=Config::get('vividstore.weightUnit')?></div>
+                                <?php echo $form->text('pWeight',$weight?$weight:'0')?>
+                                <div class="input-group-addon"><?php echo Config::get('vividstore.weightUnit')?></div>
                             </div>
                         </div>
                     </div>
@@ -301,24 +301,24 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                                 <?php echo $form->label("pLength", t("Length"));?>
                                 <div class="input-group" >
                                     <?php $length = $p->getDimensions('l'); ?>
-                                    <?=$form->text('pLength',$length?$length:'0')?>
-                                    <div class="input-group-addon"><?=Config::get('vividstore.sizeUnit')?></div>
+                                    <?php echo $form->text('pLength',$length?$length:'0')?>
+                                    <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <?php echo $form->label("pWidth", t("Width"));?>
                                 <div class="input-group" >
                                     <?php $width = $p->getDimensions('w'); ?>
-                                    <?=$form->text('pWidth',$width?$width:'0')?>
-                                    <div class="input-group-addon"><?=Config::get('vividstore.sizeUnit')?></div>
+                                    <?php echo $form->text('pWidth',$width?$width:'0')?>
+                                    <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <?php echo $form->label("pHeight", t("Height"));?>
                                 <div class="input-group">
                                     <?php $height = $p->getDimensions('h'); ?>
-                                    <?=$form->text('pHeight',$height?$height:'0')?>
-                                    <div class="input-group-addon"><?=Config::get('vividstore.sizeUnit')?></div>
+                                    <?php echo $form->text('pHeight',$height?$height:'0')?>
+                                    <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                                 </div>
                             </div>
                         </div>
@@ -337,12 +337,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 </div>
 
 
-                <h4><?=t('Additional Images')?></h4>
+                <h4><?php echo t('Additional Images')?></h4>
 
                 <div id="additional-images-container"></div>
 
                 <div class="clearfix">
-                    <span class="btn btn-default" id="btn-add-image"><?=t('Add Image')?></span>
+                    <span class="btn btn-default" id="btn-add-image"><?php echo t('Add Image')?></span>
                 </div>
 
                 <!-- THE TEMPLATE WE'LL USE FOR EACH IMAGE -->
@@ -358,7 +358,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <% if (thumb.length > 0) { %>
                             <img src="<%= thumb %>" />
                             <% } else { %>
-                            <i class="fa fa-picture-o"></i> <?=t('Choose Image');?>
+                            <i class="fa fa-picture-o"></i> <?php echo t('Choose Image');?>
                             <% } %>
                         </a>
 
@@ -415,7 +415,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <?php } else { ?>
                             thumb: '',
                             <?php } ?>
-                            sort: '<?=$count++ ?>'
+                            sort: '<?php echo $count++ ?>'
                         }));
                         <?php
                             }
@@ -447,11 +447,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
             <div class="col-sm-7 store-pane" id="product-options">
 
-                <h4><?=t('Options')?></h4>
+                <h4><?php echo t('Options')?></h4>
                 <div id="product-options-container"></div>
 
                 <div class="clearfix">
-                    <span class="btn btn-primary" id="btn-add-option-group"><?=t('Add Option Group')?></span>
+                    <span class="btn btn-primary" id="btn-add-option-group"><?php echo t('Add Option Group')?></span>
                 </div>
                 <!-- THE TEMPLATE WE'LL USE FOR EACH OPTION GROUP -->
                 <script type="text/template" id="option-group-template">
@@ -459,20 +459,20 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         <div class="panel-heading">
                             <div class="row">
                                 <div class="col-xs-3 label-shell">
-                                    <label for="pogName<%=sort%>" class="text-right"><i class="fa fa-arrows drag-handle pull-left"></i> <span class="hidden-xs"><?=t('Group Name:')?></span></label>
+                                    <label for="pogName<%=sort%>" class="text-right"><i class="fa fa-arrows drag-handle pull-left"></i> <span class="hidden-xs"><?php echo t('Group Name:')?></span></label>
                                 </div>
                                 <div class="col-xs-5">
                                     <input type="text" class="form-control" name="pogName[]" value="<%=pogName%>">
                                 </div>
                                 <div class="col-xs-4 text-right">
-                                     <a href="javascript:deleteOptionGroup(<%=sort%>)" class="btn btn-delete-item btn-danger"><i data-toggle="tooltip" data-placement="top" title="<?=t('Delete the Option Group')?>" class="fa fa-trash"></i></a>
+                                     <a href="javascript:deleteOptionGroup(<%=sort%>)" class="btn btn-delete-item btn-danger"><i data-toggle="tooltip" data-placement="top" title="<?php echo t('Delete the Option Group')?>" class="fa fa-trash"></i></a>
                                 </div>
                             </div>
                         </div>
                         <div class="panel-body">
                             <div data-group="<%=sort%>" class="option-group-item-container"></div>
 
-                            <a href="javascript:addOptionItem(<%=sort%>)" data-group="<%=sort%>" class="btn btn-default"><?=t('Add Option')?></a>
+                            <a href="javascript:addOptionItem(<%=sort%>)" data-group="<%=sort%>" class="btn btn-default"><?php echo t('Add Option')?></a>
 
                                 </div>
                             <input type="hidden" name="pogID[]" value="<%=pogID%>">
@@ -514,7 +514,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         optionsContainer.append(optionsTemplate({
                             pogName: '<?php echo $group->getName() ?>',
                             pogID: '<?php echo $group->getID()?>',
-                            sort: '<?=$group->getSort() ?>'
+                            sort: '<?php echo $group->getSort() ?>'
                         }));
                         <?php
                             }
@@ -545,10 +545,15 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     <div class="option-item clearfix form-horizontal" data-order="<%=sort%>" data-option-group="<%=optGroup%>">
                         <div class="form-group">
                             <div class="col-sm-3 text-right">
-                                <label class="grabme"><i class="fa fa-arrows drag-handle pull-left"></i><?=t('Option')?>:</label>
+                                <label class="grabme"><i class="fa fa-arrows drag-handle pull-left"></i><?php echo t('Option')?>:</label>
                             </div>
-                            <div class="col-sm-5">
+                            <div class="col-sm-7">
+                                <div class="input-group">
                                 <input type="text" name="poiName[]" class="form-control" value="<%=poiName%>">
+                                    <div class="input-group-addon">
+                                        <label><input type="checkbox" name="poiHide[]" value="1" <%=poiHidden%> /> <?php echo t('Hide'); ?></label>
+                                    </div>
+                                </div>
                                 <input type="hidden" name="poiID[]" class="form-control" value="<%=poiID%>">
                             </div>
                             <div class="col-sm-2">
@@ -592,8 +597,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         indexOptionItems();
                     }
                     $(function(){
-
-
+                        
                         //Make items sortable. If we re-sort them, re-index them.
                         $(".option-group-item-container").sortable({
                             handle: ".grabme",
@@ -616,12 +620,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                                     if($option->getProductOptionGroupID() == $groups[$i]->getID()){
 
                                     ?>
-                        var optItemsContainer = $(".option-group-item-container[data-group='<?=$i?>']");
+                        var optItemsContainer = $(".option-group-item-container[data-group='<?php echo $i?>']");
                         optItemsContainer.append(optItemsTemplate({
-                            poiName: '<?=h($option->getName())?>',
-                            poiID: '<?=$option->getID()?>',
-                            optGroup: <?=$i?>,
-                            sort: <?=$option->getSort()?>
+                            poiName: '<?php echo h($option->getName())?>',
+                            poiID: '<?php echo $option->getID()?>',
+                            optGroup: <?php echo $i?>,
+                            sort: <?php echo $option->getSort()?>,
+                            poiHidden: <?php echo ($option->isHidden() ? '\'checked="checked"\'' : '""'); ?>
 
                         }));
                         <?php
@@ -698,7 +703,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                                          <td>
                                              <div class="input-group">
                                                  <div class="input-group-addon">
-                                                     <?= Config::get('vividstore.symbol'); ?>
+                                                     <?php echo  Config::get('vividstore.symbol'); ?>
                                                  </div>
                                                  <?php echo $form->text("pvPrice[]", $variation ? $variation->getVariationPrice() : '', array('placeholder' => t('Base price'))); ?>
                                              </div>
@@ -709,7 +714,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                                          <td>
                                              <div class="input-group">
                                                  <div class="input-group-addon">
-                                                     <?= Config::get('vividstore.symbol'); ?>
+                                                     <?php echo  Config::get('vividstore.symbol'); ?>
                                                  </div>
                                                  <?php echo $form->text("pvSalePrice[]", $variation ? $variation->getVariationSalePrice() : '', array('placeholder' => t('Base sale price'))); ?>
                                              </div>
@@ -748,7 +753,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
             <div class="col-sm-7 store-pane" id="product-attributes">
                 <div class="alert alert-info">
-                    <?=t("While you can set and assign attributes, they're are currently only able to be accessed programmatically")?>
+                    <?php echo t("While you can set and assign attributes, they're are currently only able to be accessed programmatically")?>
                 </div>
                 <?php
 
@@ -801,7 +806,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 <div class="form-group">
                     <?php echo $form->checkbox('pCreateUserAccount', '1', $p->createsLogin())?>
                     <?php echo $form->label('pCreateUserAccount', t('Create user account on purchase'))?>
-                    <span class="help-block"><?= t('When checked, if customer is guest, will create a user account on purchase'); ?></span>
+                    <span class="help-block"><?php echo  t('When checked, if customer is guest, will create a user account on purchase'); ?></span>
                 </div>
 
                 <div class="form-group">
@@ -847,20 +852,20 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     <?php
                     $page = Page::getByID($p->getProductPageID());
                     if(!$page->isError()){ ?>
-                        <strong><?=t("Detail Page is set to: ")?><a href="<?=$page->getCollectionLink()?>" target="_blank"><?=$page->getCollectionName()?></a></strong>
+                        <strong><?php echo t("Detail Page is set to: ")?><a href="<?php echo $page->getCollectionLink()?>" target="_blank"><?php echo $page->getCollectionName()?></a></strong>
 
                     <?php } else { ?>
 
                         <div class="alert alert-warning">
-                            <?=t("We're not sure why, but this product doesn't seem to have a Page that correlates to it.")?>
+                            <?php echo t("We're not sure why, but this product doesn't seem to have a Page that correlates to it.")?>
                         </div>
 
                         <div class="form-group">
-                            <label><?=t("Page Template")?></label>
+                            <label><?php echo t("Page Template")?></label>
                             <?php echo $form->select('selectPageTemplate',$pageTemplates,null);?>
                         </div>
 
-                        <a href="<?=Url::to('/dashboard/store/products/generate/',$p->getProductID())?>" class="btn btn-primary" id="btn-generate-page"><?=t("Generate a Product Page")?></a>
+                        <a href="<?php echo Url::to('/dashboard/store/products/generate/',$p->getProductID())?>" class="btn btn-primary" id="btn-generate-page"><?php echo t("Generate a Product Page")?></a>
 
 
                     <?php } ?>
@@ -868,10 +873,10 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 <?php } else { ?>
 
                     <div class="alert alert-info">
-                        <?=t("When you create a product, we'll make a page for that product. Below is the available templates for the Product Page Type. Choose one, and we'll use this to create the Detail page.")?>
+                        <?php echo t("When you create a product, we'll make a page for that product. Below is the available templates for the Product Page Type. Choose one, and we'll use this to create the Detail page.")?>
                     </div>
                     <div class="form-group">
-                        <label><?=t("Page Template")?></label>
+                        <label><?php echo t("Page Template")?></label>
                         <?php echo $form->select('selectPageTemplate',$pageTemplates,null);?>
                     </div>
 
@@ -884,7 +889,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
                 <a href="<?php echo URL::to('/dashboard/store/products/')?>" class="btn btn-default pull-left"><?php echo t("Cancel")?></a>
-                <button class="pull-right btn btn-success" disabled="disabled" type="submit" ><?=t('%s Product',$actionType)?></button>
+                <button class="pull-right btn btn-success" disabled="disabled" type="submit" ><?php echo t('%s Product',$actionType)?></button>
             </div>
         </div>
 
@@ -914,9 +919,9 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             <div class="ccm-search-fields-row">
                 <?php if($grouplist){?>
                     <ul id="group-filters" class="nav nav-pills">
-                        <li><a href="<?php echo View::url('/dashboard/store/products/')?>"><?=t('All Groups')?></a></li>
+                        <li><a href="<?php echo View::url('/dashboard/store/products/')?>"><?php echo t('All Groups')?></a></li>
                         <?php foreach($grouplist as $group){ ?>
-                            <li><a href="<?php echo View::url('/dashboard/store/products/', $group->getGroupID())?>"><?=$group->getGroupName()?></a></li>
+                            <li><a href="<?php echo View::url('/dashboard/store/products/', $group->getGroupID())?>"><?php echo $group->getGroupName()?></a></li>
                         <?php } ?>
                     </ul>
                 <?php } ?>
@@ -936,14 +941,14 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
         <table class="ccm-search-results-table">
             <thead>
-            <th><a><?=t('Primary Image')?></a></th>
-            <th><a><?=t('Product Name')?></a></th>
-            <th><a><?=t('Active')?></a></th>
-            <th><a><?=t('Stock Level')?></a></th>
-            <th><a><?=t('Price')?></a></th>
-            <th><a><?=t('Featured')?></a></th>
-            <th><a><?=t('Groups')?></a></th>
-            <th><a><?=t('Actions')?></a></th>
+            <th><a><?php echo t('Primary Image')?></a></th>
+            <th><a><?php echo t('Product Name')?></a></th>
+            <th><a><?php echo t('Active')?></a></th>
+            <th><a><?php echo t('Stock Level')?></a></th>
+            <th><a><?php echo t('Price')?></a></th>
+            <th><a><?php echo t('Featured')?></a></th>
+            <th><a><?php echo t('Groups')?></a></th>
+            <th><a><?php echo t('Actions')?></a></th>
             </thead>
             <tbody>
 
@@ -952,7 +957,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     ?>
                     <tr>
                         <td><?php echo $p->getProductImageThumb();?></td>
-                        <td><strong><a href="<?php echo View::url('/dashboard/store/products/edit/', $p->getProductID())?>"><?= $p->getProductName();
+                        <td><strong><a href="<?php echo View::url('/dashboard/store/products/edit/', $p->getProductID())?>"><?php echo  $p->getProductName();
                                 $sku = $p->getProductSKU();
                                 if ($sku) {
                                     echo ' (' .$sku . ')';
@@ -968,8 +973,8 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             }
                             ?>
                         </td>
-                        <td><?= ($p->isUnlimited() ? '<span class="label label-default">' . t('Unlimited') .'</span>' : $p->getProductQty()) ?></td>
-                        <td><?= $p->getFormattedPrice() ?></td>
+                        <td><?php echo  ($p->isUnlimited() ? '<span class="label label-default">' . t('Unlimited') .'</span>' : $p->getProductQty()) ?></td>
+                        <td><?php echo  $p->getFormattedPrice() ?></td>
                         <td>
                             <?php
                             if ($p->isFeatured()) {
@@ -982,11 +987,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                         <td>
                             <?php $productgroups = $p->getProductGroups();
                             foreach($productgroups as $pg) { ?>
-                                <span class="label label-primary"><?= $pg->gName; ?></span>
+                                <span class="label label-primary"><?php echo  $pg->gName; ?></span>
                              <?php } ?>
 
                             <?php if (empty($productgroups)) { ?>
-                                <em><?= t('None');?></em>
+                                <em><?php echo  t('None');?></em>
                             <?php } ?>
                         </td>
                         <td>
@@ -1002,7 +1007,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
         <?php if ($paginator->getTotalPages() > 1) { ?>
             <div class="ccm-search-results-pagination">
-                <?= $pagination ?>
+                <?php echo  $pagination ?>
             </div>
         <?php } ?>
 
@@ -1011,12 +1016,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 <?php } elseif (in_array($controller->getTask(),$groupViews)){ ?>
 
     <?php if($grouplist){ ?>
-        <h3><?=t("Groups")?></h3>
+        <h3><?php echo t("Groups")?></h3>
         <ul class="list-unstyled group-list" data-delete-url="<?php echo View::url('/dashboard/store/products/deletegroup')?>" data-save-url="<?php echo View::url('/dashboard/store/products/editgroup')?>">
             <?php foreach($grouplist as $group){?>
-                <li data-group-id="<?=$group->getGroupID()?>">
-                    <span class="group-name"><?=$group->getGroupName()?></span>
-                    <input class="hideme edit-group-name" type="text" value="<?=$group->getGroupName()?>">
+                <li data-group-id="<?php echo $group->getGroupID()?>">
+                    <span class="group-name"><?php echo $group->getGroupName()?></span>
+                    <input class="hideme edit-group-name" type="text" value="<?php echo $group->getGroupName()?>">
                     <span class="btn btn-default btn-edit-group-name"><i class="fa fa-pencil"></i></span>
                     <span class="hideme btn btn-default btn-cancel-edit"><i class="fa fa-ban"></i></span>
                     <span class="hideme btn btn-warning btn-save-group-name"><i class="fa fa-save"></i></span>
@@ -1027,17 +1032,17 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
     <?php } else { ?>
 
-        <div class="alert alert-info"><?=t("You have not added a group yet")?></div>
+        <div class="alert alert-info"><?php echo t("You have not added a group yet")?></div>
 
     <?php } ?>
-    <form method="post" action="<?=$view->action('addgroup')?>">
-        <h4><?=t('Add a Group')?></h4>
+    <form method="post" action="<?php echo $view->action('addgroup')?>">
+        <h4><?php echo t('Add a Group')?></h4>
         <hr>
         <div class="form-group">
             <?php echo $form->label('groupName',t("Group Name")); ?>
             <?php echo $form->text('groupName',null,array('style'=>'width:200px')); ?>
         </div>
-        <input type="submit" class="btn btn-primary" value="<?=t('Add Group');?>">
+        <input type="submit" class="btn btn-primary" value="<?php echo t('Add Group');?>">
     </form>
 
 <?php }  ?>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -490,6 +490,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                     function deleteOptionGroup(id){
                         $(".option-group[data-order='"+id+"']").remove();
                         $('#variationshider').addClass('hidden');
+                        $('#changenotice').removeClass('hidden');
                     }
                     $(function(){
                         function indexOptionGroups(){
@@ -544,6 +545,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                             indexOptionGroups();
 
                             $('#variationshider').addClass('hidden');
+                            $('#changenotice').removeClass('hidden');
                         });
                     });
 
@@ -677,7 +679,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                 <h4><?php echo t('Variations');?></h4>
 
                 <?php if ($pID) { ?>
-                    <p class="alert alert-info hidden" id="changenotice"><?php echo t('Product options have changed, update the product to edited updated variations') ?></p>
+                    <p class="alert alert-info hidden" id="changenotice"><?php echo t('Product options have changed, update the product to configure updated variations') ?></p>
                 <?php } ?>
 
 
@@ -703,17 +705,19 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
 
                          ?>
                         <button class="btn btn-xs btn-default pull-right variationdisplaybutton" type="button" data-toggle="collapse">
-                            <?php echo t('Configure');?>
+                            <?php echo t('More options');?>
                         </button>
                     </div>
 
-                     <div class="panel-body hidden">
+                     <div class="panel-body">
                          <input type="hidden" name="option_combo[]" value="<?php echo implode('_', $comboIDs); ?>"/>
 
                          <?php if (isset($variationLookup[implode('_', $comboIDs)])) {
                              $variation = $variationLookup[implode('_', $comboIDs)];
+                             $varid = $variation->getID();
                          } else {
                              $variation = null;
+                             $varid = '';
                          } ?>
 
                         <div class="row form-group">
@@ -721,10 +725,32 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                              <?php echo $form->label("", t("SKU")); ?>
                          </div>
                          <div class="col-md-8">
-                            <?php echo $form->text("pvSKU[]", $variation ? $variation->getVariationSKU() : '', array('placeholder' => t('Base SKU'))); ?>
+                            <?php echo $form->text("pvSKU[".$varid."]", $variation ? $variation->getVariationSKU() : '', array('placeholder' => t('Base SKU'))); ?>
                          </div>
                         </div>
-                        <div class="row form-group">
+
+                         <div class="row form-group">
+                             <div class="col-md-4">
+                                 <?php echo $form->label("", t("Stock Level")); ?>
+                             </div>
+                             <div class="col-md-8">
+                                 <div class="input-group">
+                                     <?php
+                                     if ($variation) {
+                                         echo $form->text("pvQty[".$varid."]", $variation->getVariationQty(), array(($variation->isUnlimited() ? 'readonly' : '')=>($variation->isUnlimited() ? 'readonly' : '')));
+                                     } else {
+                                         echo $form->text("pvQty[".$varid."]", '', array('readonly'=>'readonly'));
+                                     }
+                                     ?>
+
+                                     <div class="input-group-addon">
+                                         <label><?php echo $form->checkbox('pvQtyUnlim['.$varid.']', '1', $variation ? $variation->isUnlimited() : true) ?> <?php echo t('Unlimited'); ?></label>
+                                     </div>
+                                 </div>
+                             </div>
+                         </div>
+
+                         <div class="row form-group">
                          <div class="col-md-4">
                             <?php echo $form->label("", t("Price")); ?>
                          </div>
@@ -733,11 +759,14 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                                  <div class="input-group-addon">
                                      <?php echo  Config::get('vividstore.symbol'); ?>
                                  </div>
-                                 <?php echo $form->text("pvPrice[]", $variation ? $variation->getVariationPrice() : '', array('placeholder' => t('Base Price'))); ?>
+                                 <?php echo $form->text("pvPrice[".$varid."]", $variation ? $variation->getVariationPrice() : '', array('placeholder' => t('Base Price'))); ?>
                             </div>
                         </div>
                         </div>
-                        <div class="row form-group">
+
+                         <div class="extrafields hidden">
+
+                         <div class="row form-group">
                          <div class="col-md-4">
                                 <?php echo $form->label("pvSalePrice[]", t("Sale Price")); ?>
                          </div>
@@ -746,30 +775,12 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                                  <div class="input-group-addon">
                                      <?php echo  Config::get('vividstore.symbol'); ?>
                                  </div>
-                                 <?php echo $form->text("pvSalePrice[]", $variation ? $variation->getVariationSalePrice() : '', array('placeholder' => t('Base Sale Price'))); ?>
+                                 <?php echo $form->text("pvSalePrice[".$varid."]", $variation ? $variation->getVariationSalePrice() : '', array('placeholder' => t('Base Sale Price'))); ?>
                              </div>
                          </div>
                         </div>
-                        <div class="row form-group">
-                         <div class="col-md-4">
-                            <?php echo $form->label("", t("Stock Level")); ?>
-                         </div>
-                         <div class="col-md-8">
-                             <div class="input-group">
-                                     <?php
-                                     if ($variation) {
-                                         echo $form->text("pvQty[]", $variation->getVariationQty(), array(($variation->isUnlimited() ? 'readonly' : '')=>($variation->isUnlimited() ? 'readonly' : '')));
-                                     } else {
-                                         echo $form->text("pvQty[]", '', array('readonly'=>'readonly'));
-                                     }
-                                     ?>
 
-                                     <div class="input-group-addon">
-                                     <label><?php echo $form->checkbox('pvQtyUnlim[]', '1', $variation ? $variation->isUnlimited() : true) ?> <?php echo t('Unlimited'); ?></label>
-                                 </div>
-                             </div>
-                         </div>
-                        </div>
+
                          <div class="row form-group">
                              <div class="col-md-12">
                                  <?php echo $form->label('pfID[]',t("Primary Image")); ?>
@@ -779,7 +790,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                                      $pvfID = $variation->getVariationImageID();
                                  }
                                   ?>
-                                 <?php echo $al->image('ccm-image'.$count++, 'pvfID[]', t('Choose Image'), $pvfID?File::getByID($pvfID):null); ?>
+                                 <?php echo $al->image('ccm-image'.$count++, 'pvfID['.$varid.']', t('Choose Image'), $pvfID?File::getByID($pvfID):null); ?>
                              </div>
                          </div>
                         <div class="row form-group">
@@ -788,7 +799,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                         </div>
                         <div class="col-md-8">
                             <div class="input-group" >
-                                <?php echo $form->text('pvWeight[]',$variation ? $variation->getVariationWeight() : '', array('placeholder'=>t('Base Weight')))?>
+                                <?php echo $form->text('pvWeight['.$varid.']',$variation ? $variation->getVariationWeight() : '', array('placeholder'=>t('Base Weight')))?>
                                 <div class="input-group-addon"><?php echo Config::get('vividstore.weightUnit')?></div>
                             </div>
                          </div>
@@ -798,7 +809,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                             <?php echo $form->label("", t("Number of Items")); ?>
                         </div>
                         <div class="col-md-8">
-                             <?php echo $form->text('pvNumberItems[]',$variation ? $variation->getVariationNumberItems() : '', array('min'=>0, 'step'=>1, 'placeholder'=>t('Base Number Of Items')))?>
+                             <?php echo $form->text('pvNumberItems['.$varid.']',$variation ? $variation->getVariationNumberItems() : '', array('min'=>0, 'step'=>1, 'placeholder'=>t('Base Number Of Items')))?>
                          </div>
                         </div>
                         <div class="row form-group">
@@ -807,7 +818,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                         </div>
                         <div class="col-md-8">
                              <div class="input-group" >
-                                 <?php echo $form->text('pvLength[]',$variation ? $variation->getVariationLength() : '', array('placeholder'=>t('Base Length')))?>
+                                 <?php echo $form->text('pvLength['.$varid.']',$variation ? $variation->getVariationLength() : '', array('placeholder'=>t('Base Length')))?>
                                  <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                              </div>
                         </div>
@@ -819,7 +830,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
 
                          <div class="col-md-8">
                              <div class="input-group" >
-                                     <?php echo $form->text('pvWidth[]',$variation ? $variation->getVariationWidth() : '', array('placeholder'=>t('Base Width')))?>
+                                     <?php echo $form->text('pvWidth['.$varid.']',$variation ? $variation->getVariationWidth() : '', array('placeholder'=>t('Base Width')))?>
                                      <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                              </div>
                           </div>
@@ -830,12 +841,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                         </div>
                          <div class="col-md-8">
                              <div class="input-group" >
-                                     <?php echo $form->text('pvHeight[]',$variation ? $variation->getVariationHeight() : '', array('placeholder'=>t('Base Height')))?>
+                                     <?php echo $form->text('pvHeight['.$varid.']',$variation ? $variation->getVariationHeight() : '', array('placeholder'=>t('Base Height')))?>
                                      <div class="input-group-addon"><?php echo Config::get('vividstore.sizeUnit')?></div>
                              </div>
                          </div>
                         </div>
                     </div>
+                     </div>
 
                  </div>
                  <?php } ?>
@@ -993,7 +1005,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
 
             $(function(){
                 $('.variationdisplaybutton').click(function(el) {
-                   $(this).closest('.panel').find('.panel-body').toggleClass('hidden');
+                   $(this).closest('.panel').find('.extrafields').toggleClass('hidden');
                     el.preventDefault();
                 });
             });

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -1082,8 +1082,20 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
                             }
                             ?>
                         </td>
-                        <td><?php echo  ($p->isUnlimited() ? '<span class="label label-default">' . t('Unlimited') .'</span>' : $p->getProductQty()) ?></td>
-                        <td><?php echo  $p->getFormattedPrice() ?></td>
+                        <td><?php
+                            if ($p->hasVariations()) {
+                                echo '<span class="label label-info">' . t('Multiple') . '</span>';
+                            } else {
+                                echo($p->isUnlimited() ? '<span class="label label-default">' . t('Unlimited') . '</span>' : $p->getProductQty());
+                            }?></td>
+                        <td>
+                            <?php
+                            if ($p->hasVariations()) {
+                                echo '<span class="label label-info">' . t('Multiple') . '</span><br />';
+                                echo t('Base price') . ': ' . $p->getFormattedPrice();
+                            } else {
+                                echo $p->getFormattedPrice();
+                            } ?></td>
                         <td>
                             <?php
                             if ($p->isFeatured()) {

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -57,10 +57,16 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
             <div class="col-sm-7 store-pane active" id="product-overview">
 
                 <div class="row">
-                    <div class="col-xs-12">
+                    <div class="col-xs-8">
                         <div class="form-group">
                             <?php echo $form->label("pName", t("Product Name"));?>
                             <?php echo $form->text("pName", $p->getProductName());?>
+                        </div>
+                    </div>
+                    <div class="col-xs-4">
+                        <div class="form-group">
+                            <?php echo $form->label("pSKU", t("Code / SKU"));?>
+                            <?php echo $form->text("pSKU", $p->getProductSKU());?>
                         </div>
                     </div>
                 </div>
@@ -584,15 +590,18 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
 
                         //load up items
                         <?php
+
                         if($optItems) {
                             $count = count($groups);
                             for($i=0;$i<$count;$i++){
                                 foreach($optItems as $option){
                                     //go through all options, see if it belongs in the group we're on in the for loop
-                                    if($option->getProductOptionGroupID() == $groups[$i]->getID()){?>
+                                    if($option->getProductOptionGroupID() == $groups[$i]->getID()){
+
+                                    ?>
                         var optItemsContainer = $(".option-group-item-container[data-group='<?=$i?>']");
                         optItemsContainer.append(optItemsTemplate({
-                            poiName: '<?=$option->getName()?>',
+                            poiName: '<?=h($option->getName())?>',
                             poiID: '<?=$option->getID()?>',
                             optGroup: <?=$i?>,
                             sort: <?=$option->getSort()?>
@@ -611,6 +620,74 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     });
 
                 </script>
+
+            <br />
+            <h4><?php echo t('Variations');?></h4>
+
+            <table class="table table-bordered">
+                <tr>
+                    <th><?php echo t('Options');?></th>
+                    <th><?php echo t('Variation');?></th>
+                    <th><?php echo t('Stock Level');?></th>
+                </tr>
+
+                 <?php
+                  foreach($comboOptions as $combinedOptions) {
+                       ?>
+                        <tr>
+                            <td>
+                                <?php
+                                $comboIDs = array();
+
+                                foreach($combinedOptions as $optionItemID) {
+                                    $comboIDs[] =  $optionItemID;
+                                    sort($comboIDs);
+
+                                    echo '<span class="label label-primary">' .  $groupLookup[$optionItemLookup[$optionItemID]->getProductOptionGroupID()]->getName() . ': '.  $optionItemLookup[$optionItemID]->getName() . '</span><br />';
+                                }?>
+
+                                <input type="hidden" name="option_combo[]" value="<?php echo implode('_', $comboIDs);?>" />
+
+                                <?php if (isset($variationLookup[implode('_', $comboIDs)])) {
+                                    $variation = $variationLookup[implode('_', $comboIDs)];
+                                } else {
+                                    $variation = null;
+                                } ?>
+
+                            </td>
+                            <td>
+                                <div class="form-group">
+                                    <?php echo $form->label("pvSKU[]", t("SKU"));?>
+                                <?php echo $form->text("pvSKU[]", $variation?$variation->getVariationSKU():'');?>
+                                 </div>
+
+                                <?php echo $form->label("pvPrice[]", t("Price"));?>
+                                <div class="input-group">
+
+                                <div class="input-group-addon">
+                                    <?= Config::get('vividstore.symbol');?>
+                                </div>
+
+                                <?php echo $form->text("pvPrice[]", $variation?$variation->getVariationPrice():'', array('placeholder'=>t('Base price')));?>
+                                    </div>
+                            </td>
+
+                            <td>
+                                <div class="input-group">
+                                    <?php echo $form->text("pvQty[]", $variation ? $variation->getVariationQty() : '');?>
+                                        <br /><label><?php echo $form->checkbox('pvQtyUnlim[]', '1', $variation ? $variation->isUnlimited() : true)?> <?php echo t('Unlimited');?></label>
+
+                                </div>
+                            </td>
+                        </tr>
+                    <?php
+
+
+                   } ?>
+
+            </table>
+
+
 
             </div><!-- #product-options -->
 
@@ -820,7 +897,13 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     ?>
                     <tr>
                         <td><?php echo $p->getProductImageThumb();?></td>
-                        <td><strong><a href="<?php echo View::url('/dashboard/store/products/edit/', $p->getProductID())?>"><?= $p->getProductName() ?></a></strong></td>
+                        <td><strong><a href="<?php echo View::url('/dashboard/store/products/edit/', $p->getProductID())?>"><?= $p->getProductName();
+                                $sku = $p->getProductSKU();
+                                if ($sku) {
+                                    echo ' (' .$sku . ')';
+                                }
+                                ?>
+                                </a></strong></td>
                         <td>
                             <?php
                             if ($p->isActive()) {

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -475,9 +475,10 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                             <a href="javascript:addOptionItem(<%=sort%>)" data-group="<%=sort%>" class="btn btn-default"><?=t('Add Option')?></a>
 
                                 </div>
+                            <input type="hidden" name="pogID[]" value="<%=pogID%>">
+                            <input type="hidden" name="pogSort[]" value="<%=sort%>" class="option-group-sort">
                         </div>
-                        <input type="hidden" name="pogID[]" value="<%=pogID%>">
-                        <input type="hidden" name="pogSort[]" value="<%=sort%>" class="option-group-sort">
+
                     </div><!-- .option-group -->
                 </script>
                 <script type="text/javascript">

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -545,7 +545,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                     <div class="option-item clearfix form-horizontal" data-order="<%=sort%>" data-option-group="<%=optGroup%>">
                         <div class="form-group">
                             <div class="col-sm-3 text-right">
-                                <label class="grabme"><?=t('Option')?>:</label>
+                                <label class="grabme"><i class="fa fa-arrows drag-handle pull-left"></i><?=t('Option')?>:</label>
                             </div>
                             <div class="col-sm-5">
                                 <input type="text" name="poiName[]" class="form-control" value="<%=poiName%>">
@@ -645,9 +645,9 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 <?php echo t('Options have different prices, SKUs or stock levels');?></label>
             </div>
 
+            <?php if (!empty($comboOptions)) { ?>
             <div id="variations" class="<?php echo ($p->hasVariations() ? '' : 'hidden');?>">
             <h4><?php echo t('Variations');?></h4>
-
             <table class="table table-bordered">
                 <tr>
                     <th><?php echo t('Options');?></th>
@@ -655,7 +655,6 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                 </tr>
 
                  <?php
-                 if (!empty($comboOptions)) {
                      foreach ($comboOptions as $combinedOptions) {
                          ?>
                          <tr>
@@ -739,10 +738,11 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\Product as VividProduct;
                          </tr>
                          <?php
                      }
-                 }?>
+                 ?>
 
             </table>
             </div>
+            <?php } ?>
 
             </div><!-- #product-options -->
 

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -189,7 +189,7 @@ class Cart
                 $newquantity = $product->getProductQty();
             }
 
-           // $cart[$exists]['product']['qty'] = $newquantity;
+            $cartItem['product']['qty'] = $newquantity;
 
             if ($product->isExclusive()) {
                 $cart = array($cartItem);

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -143,9 +143,18 @@ class Cart
 
             // association the variation with the product
             if ($variation) {
-                $product->setVariation($variation);
-                $cartItem['product']['variation'] = $variation->getID();
+                $options = $variation->getOptions();
+                if (count($options) == count($optionItemIds)) {  // check if we've matched to a variation with the correct number of options
+                    $product->setVariation($variation);
+                    $cartItem['product']['variation'] = $variation->getID();
+                } else {
+                    return false;
+                }
+            } else {
+                return false; // variation not matched
             }
+        } elseif ($product->hasVariations()) {
+            return false;  // if we have a product with variations, but no variation data was submitted, it's a broken add-to-cart form
         }
 
 

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -144,9 +144,8 @@ class Cart
             // association the variation with the product
             if ($variation) {
                 $product->setVariation($variation);
+                $cartItem['product']['variation'] = $variation->getID();
             }
-
-            $cartItem['product']['variation'] = $variation->getID();
         }
 
 

--- a/src/VividStore/Cart/Cart.php
+++ b/src/VividStore/Cart/Cart.php
@@ -41,7 +41,17 @@ class Cart
                         $update = true;
                     }
 
-                    $checkeditems[] = $cartitem;
+                    $include = true;
+
+                    if ( $cartitem['product']['variation']) {
+                        if (!StoreProductVariation::getByID($cartitem['product']['variation'])) {
+                            $include = false;
+                        }
+                    }
+
+                    if ($include) {
+                        $checkeditems[] = $cartitem;
+                    }
                 } else {
                     $update = true;
                 }

--- a/src/VividStore/Order/OrderItem.php
+++ b/src/VividStore/Order/OrderItem.php
@@ -21,10 +21,16 @@ class OrderItem extends Object
     }
     public function add($data,$oID,$tax=0,$taxIncluded=0,$taxName='')
     {
-        $db = Database::get();
+        $db = Database::connection();
         $product = StoreProduct::getByID($data['product']['pID']);
+
+        if ($data['product']['variation']) {
+            $product->setVariation($data['product']['variation']);
+        }
+
         $productName = $product->getProductName();
         $productPrice = $product->getActivePrice();
+        $sku = $product->getProductSKU();
         $qty = $data['product']['qty'];
         if (!$product->isUnlimited()) {
             $inStock = $product->getProductQty();
@@ -32,8 +38,8 @@ class OrderItem extends Object
             $product->updateProductQty($newStock);
         }
         $pID = $product->getProductID();
-        $values = array($oID,$pID,$productName,$productPrice,$tax,$taxIncluded,$taxName,$qty);
-        $db->Execute("INSERT INTO VividStoreOrderItems (oID,pID,oiProductName,oiPricePaid,oiTax,oiTaxIncluded,oiTaxName,oiQty) VALUES (?,?,?,?,?,?,?,?)",$values);
+        $values = array($oID,$pID,$productName,$sku,$productPrice,$tax,$taxIncluded,$taxName,$qty);
+        $db->Execute("INSERT INTO VividStoreOrderItems (oID,pID,oiProductName,oiSKU,oiPricePaid,oiTax,oiTaxIncluded,oiTaxName,oiQty) VALUES (?,?,?,?,?,?,?,?,?)",$values);
         
         $oiID = $db->lastInsertId();
         
@@ -41,7 +47,6 @@ class OrderItem extends Object
             $optionGroupID = str_replace("pog","",$optionGroup);
             $optionGroupName = OrderItem::getProductOptionGroupNameByID($optionGroupID);
             $optionValue = OrderItem::getProductOptionValueByID($selectedOption);
-            
             
             $values = array($oiID,$optionGroupName,$optionValue);
             $db->Execute("INSERT INTO VividStoreOrderItemOptions (oiID,oioKey,oioValue) VALUES (?,?,?)",$values);
@@ -69,6 +74,7 @@ class OrderItem extends Object
     public function getOrderItemID(){ return $this->oiID; }
     public function getProductID(){ return $this->pID; }
     public function getProductName(){ return $this->oiProductName; }
+    public function getSKU(){return $this->oiSKU; }
     public function getPricePaid() { return $this->oiPricePaid; }
     public function getQty() { return $this->oiQty; }
     public function getSubTotal()
@@ -80,17 +86,17 @@ class OrderItem extends Object
     }
     public function getProductOptions()
     {
-        return Database::get()->GetAll("SELECT * FROM VividStoreOrderItemOptions WHERE oiID=?",$this->oiID);
+        return Database::connection()->GetAll("SELECT * FROM VividStoreOrderItemOptions WHERE oiID=?",$this->oiID);
     }
     public function getProductOptionGroupNameByID($id)
     {
-        $db = Database::get();
+        $db = Database::connection();
         $optionGroup = $db->GetRow("SELECT * FROM VividStoreProductOptionGroups WHERE pogID=?",$id);
         return $optionGroup['pogName'];
     }
      public function getProductOptionValueByID($id)
     {
-        $db = Database::get();
+        $db = Database::connection();
         $optionItem = $db->GetRow("SELECT * FROM VividStoreProductOptionItems WHERE poiID=?",$id);
         return $optionItem['poiName'];
     }

--- a/src/VividStore/Order/OrderItem.php
+++ b/src/VividStore/Order/OrderItem.php
@@ -32,11 +32,20 @@ class OrderItem extends Object
         $productPrice = $product->getActivePrice();
         $sku = $product->getProductSKU();
         $qty = $data['product']['qty'];
-        if (!$product->isUnlimited()) {
-            $inStock = $product->getProductQty();
-            $newStock = $inStock - $qty;
+
+        $inStock = $product->getProductQty();
+        $newStock = $inStock - $qty;
+
+        $variation = $product->getVariation();
+
+        if ($variation) {
+            if (!$variation->isUnlimited()) {
+                $product->updateProductQty($newStock);
+            }
+        } elseif (!$product->isUnlimited()) {
             $product->updateProductQty($newStock);
         }
+
         $pID = $product->getProductID();
         $values = array($oID,$pID,$productName,$sku,$productPrice,$tax,$taxIncluded,$taxName,$qty);
         $db->Execute("INSERT INTO VividStoreOrderItems (oID,pID,oiProductName,oiSKU,oiPricePaid,oiTax,oiTaxIncluded,oiTaxName,oiQty) VALUES (?,?,?,?,?,?,?,?,?)",$values);

--- a/src/VividStore/Product/Product.php
+++ b/src/VividStore/Product/Product.php
@@ -460,7 +460,7 @@ class Product
     public function getProductLocationPages() { return StoreProductLocation::getLocationsForProduct($this); }
 
     public function getProductOptionGroups() { return StoreProductOptionGroup::getOptionGroupsForProduct($this); }
-    public function getProductOptionItems() { return StoreProductOptionItem::getOptionItemsForProduct($this); }
+    public function getProductOptionItems($onlyvisible = false) { return StoreProductOptionItem::getOptionItemsForProduct($this, $onlyvisible); }
 
     public function getProductGroupIDs() { return StoreProductGroup::getGroupIDsForProduct($this); }
     public function getProductGroups() { return StoreProductGroup::getGroupsForProduct($this); }

--- a/src/VividStore/Product/Product.php
+++ b/src/VividStore/Product/Product.php
@@ -246,7 +246,7 @@ class Product
         $product->setProductSalePrice($data['pSalePrice']);
         $product->setIsFeatured($data['pFeatured']);
         $product->setProductQty($data['pQty']);
-        $product->setIsUnlimited($data['$productpQtyUnlim']);
+        $product->setIsUnlimited($data['pQtyUnlim']);
         $product->setAllowBackOrder($data['pBackOrder']);
         $product->setNoQty($data['pNoQty']);
         $product->setProductTaxClass($data['pTaxClass']);
@@ -274,7 +274,13 @@ class Product
     public function getProductSKU(){
         if ($this->hasVariations() && $variation = $this->getVariation()) {
             if ($variation) {
-                return $variation->getVariationSKU();
+                $varsku = $variation->getVariationSKU();
+
+                if ($varsku) {
+                    return $varsku;
+                } else {
+                    return $this->pSKU;
+                }
             }
         } else {
             return $this->pSKU;
@@ -286,7 +292,13 @@ class Product
     public function getProductPrice(){
         if ($this->hasVariations() && $variation = $this->getVariation()) {
             if ($variation) {
-                return $variation->getVariationPrice();
+                $varprice = $variation->getVariationPrice();
+
+                if ($varprice) {
+                    return $varprice;
+                } else {
+                    return $this->pPrice;
+                }
             }
         } else {
             return $this->pPrice;
@@ -371,13 +383,17 @@ class Product
     
     public function isSellable()
     {
-        if($this->getProductQty() > 0 || $this->isUnlimited()){
-            return true;
+        if ($this->hasVariations() && $variation = $this->getVariation()) {
+           return $variation->isSellable();
         } else {
-            if($this->allowBackOrders()){
+            if($this->getProductQty() > 0 || $this->isUnlimited()){
                 return true;
             } else {
-                return false;
+                if($this->allowBackOrders()){
+                    return true;
+                } else {
+                    return false;
+                }
             }
         }
     }

--- a/src/VividStore/Product/Product.php
+++ b/src/VividStore/Product/Product.php
@@ -296,7 +296,14 @@ class Product
         $product->setNumberItems($data['pNumberItems']);
         $product->setAutoCheckout($data['pAutoCheckout']);
         $product->setIsExclusive($data['pExclusive']);
-        $product->setHasVariations($data['pVariations']);
+
+        // if we have no product groups, we don't have variations to offer
+        if (empty($data['pogName'])) {
+            $product->setHasVariations(0);
+        } else {
+            $product->setHasVariations($data['pVariations']);
+        }
+
         $product->save();
         if(!$data['pID']){
             $product->generatePage($data['selectPageTemplate']);
@@ -425,6 +432,7 @@ class Product
             return $this->pNumberItems;
         }
     }
+
     public function getProductImageID() {
         if ($this->hasVariations() && $variation = $this->getVariation()) {
             return $variation->getVariationImageID();
@@ -434,10 +442,22 @@ class Product
     }
     public function getProductImageObj(){
         if($this->getProductImageID()){
-            $fileObj = File::getByID($this->pfID);
+            $fileObj = File::getByID($this->getProductImageID());
             return $fileObj;
         }
     }
+
+    public function getBaseProductImageID() {
+       return $this->pfID;;
+    }
+
+    public function getBaseProductImageObj(){
+        if($this->getBaseProductImageID()){
+            $fileObj = File::getByID($this->getBaseProductImageID());
+            return $fileObj;
+        }
+    }
+
     public function hasDigitalDownload() { return count($this->getProductDownloadFiles()) > 0 ? true : false; }
     public function getProductDownloadFiles(){ return StoreProductFile::getFilesForProduct($this); }
     public function getProductDownloadFileObjects(){ return StoreProductFile::getFileObjectsForProduct($this); }

--- a/src/VividStore/Product/ProductList.php
+++ b/src/VividStore/Product/ProductList.php
@@ -28,7 +28,6 @@ class ProductList extends AttributedItemList
         $this->gIDs = array_merge($this->gIDs, $groupIDs);
     }
 
-
     public function setSortBy($sort)
     {
         $this->sortBy = $sort;

--- a/src/VividStore/Product/ProductOption/ProductOption.php
+++ b/src/VividStore/Product/ProductOption/ProductOption.php
@@ -28,23 +28,30 @@ class ProductOption
                 }
 
                 if (!$optionGroup) {
-                    $optionGroup = StoreProductOptionGroup::add($product,$data['pogName'][$i],$data['pogSort'][$i]);
+                    if ($data['pogName'][$i]) {
+                        $optionGroup = StoreProductOptionGroup::add($product,$data['pogName'][$i],$data['pogSort'][$i]);
+                    }
                 }
 
-                $pogID = $optionGroup->getID();
-                //add option items
-                $itemsInGroup = count($data['optGroup'.$i]);
-                if($itemsInGroup>0){
-                    for($gi=0;$gi<$itemsInGroup;$gi++,$ii++){
+                if ($optionGroup) {
+                    $pogID = $optionGroup->getID();
+                    //add option items
+                    $itemsInGroup = count($data['optGroup'.$i]);
+                    if($itemsInGroup>0){
+                        for($gi=0;$gi<$itemsInGroup;$gi++,$ii++){
 
-                        if ($data['poiID'][$ii] > 0) {
-                            $option = StoreProductOptionItem::getByID($data['poiID'][$ii]);
-                            $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii]);
-                        } else {
-                            StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                            if ($data['poiID'][$ii] > 0) {
+                                $option = StoreProductOptionItem::getByID($data['poiID'][$ii]);
+                                $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                            } else {
+                                if ($data['poiName'][$ii]) {
+                                    StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                                }
+                            }
                         }
                     }
                 }
+
             }
         }
     }

--- a/src/VividStore/Product/ProductOption/ProductOption.php
+++ b/src/VividStore/Product/ProductOption/ProductOption.php
@@ -10,7 +10,6 @@ class ProductOption
 {
     public static function addProductOptions($data,$product)
     {
-
         StoreProductOptionGroup::removeOptionGroupsForProduct($product, $data['pogID']);
         StoreProductOptionItem::removeOptionItemsForProduct($product, $data['poiID']);
 

--- a/src/VividStore/Product/ProductOption/ProductOption.php
+++ b/src/VividStore/Product/ProductOption/ProductOption.php
@@ -41,10 +41,10 @@ class ProductOption
 
                             if ($data['poiID'][$ii] > 0) {
                                 $option = StoreProductOptionItem::getByID($data['poiID'][$ii]);
-                                $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                                $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii],$data['poiHidden'][$ii] );
                             } else {
                                 if ($data['poiName'][$ii]) {
-                                    StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii]);
+                                    StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii], $data['poiHidden'][$ii]);
                                 }
                             }
                         }

--- a/src/VividStore/Product/ProductOption/ProductOption.php
+++ b/src/VividStore/Product/ProductOption/ProductOption.php
@@ -41,7 +41,9 @@ class ProductOption
 
                             if ($data['poiID'][$ii] > 0) {
                                 $option = StoreProductOptionItem::getByID($data['poiID'][$ii]);
-                                $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii],$data['poiHidden'][$ii] );
+                                if ($option) {
+                                    $option->update($product,$data['poiName'][$ii],$data['poiSort'][$ii],$data['poiHidden'][$ii] );
+                                }
                             } else {
                                 if ($data['poiName'][$ii]) {
                                     StoreProductOptionItem::add($product,$pogID,$data['poiName'][$ii],$data['poiSort'][$ii], $data['poiHidden'][$ii]);

--- a/src/VividStore/Product/ProductOption/ProductOptionItem.php
+++ b/src/VividStore/Product/ProductOption/ProductOptionItem.php
@@ -39,6 +39,12 @@ class ProductOptionItem
      */
     protected $poiSort;
 
+    /** @OneToMany(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariationOptionItem", mappedBy="option", cascade={"persist", "remove"})
+    * @JoinColumn(name="poiID", referencedColumnName="poiID", onDelete="CASCADE")
+    */
+    private $variationoptionitems;
+
+
     private function setProductID($pID){ $this->pID = $pID; }
     private function setProductOptionGroupID($id){ $this->pogID = $id; }
     private function setProductOptionItemName($name){ $this->poiName = $name; }

--- a/src/VividStore/Product/ProductOption/ProductOptionItem.php
+++ b/src/VividStore/Product/ProductOption/ProductOptionItem.php
@@ -39,6 +39,12 @@ class ProductOptionItem
      */
     protected $poiSort;
 
+    /**
+     * @Column(type="boolean")
+     */
+    protected $poiHidden = 0;
+
+
     /** @OneToMany(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariationOptionItem", mappedBy="option", cascade={"persist", "remove"})
     * @JoinColumn(name="poiID", referencedColumnName="poiID", onDelete="CASCADE")
     */
@@ -50,12 +56,15 @@ class ProductOptionItem
     private function setProductOptionItemName($name){ $this->poiName = $name; }
     private function setSort($sort){ $this->poiSort = $sort; }
     private function setName($name){ $this->poiName = $name; }
+    private function setHidden($hidden){ $this->poiHidden = (bool)$hidden; }
 
     public function getID(){ return $this->poiID; }
     public function getProductID() { return $this->pID; }
     public function getProductOptionGroupID() { return $this->pogID; }
     public function getName(){ return $this->poiName; }
     public function getSort() { return $this->poiSort; }
+    public function getHidden() { return $this->poiHidden; }
+    public function isHidden() { return (bool)$this->poiHidden;}
 
     public static function getByID($id) {
         $db = Database::connection();
@@ -63,11 +72,15 @@ class ProductOptionItem
         return $em->find('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem', $id);
     }
 
-    public static function getOptionItemsForProduct(StoreProduct $product)
+    public static function getOptionItemsForProduct(StoreProduct $product, $onlyvisible = false)
     {
         $db = Database::connection();
         $em = $db->getEntityManager();
-        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pID' => $product->getProductID()), array('poiSort'=>'asc'));
+        if ($onlyvisible) {
+            return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pID' => $product->getProductID(), 'poiHidden' =>'0' ), array('poiSort'=>'asc'));
+        } else{
+            return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem')->findBy(array('pID' => $product->getProductID()), array('poiSort'=>'asc'));
+        }
     }
 
     public static function getOptionItemsForProductOptionGroup(ProductOptionGroup $pog)
@@ -92,7 +105,7 @@ class ProductOptionItem
         }
     }
 
-    public static function add(StoreProduct $product,$pogID,$name,$sort)
+    public static function add(StoreProduct $product,$pogID,$name,$sort, $hidden = false)
     {
         $productOptionItem = new self();
         $pID = $product->getProductID();
@@ -100,17 +113,19 @@ class ProductOptionItem
         $productOptionItem->setProductOptionGroupID($pogID);
         $productOptionItem->setProductOptionItemName($name);
         $productOptionItem->setSort($sort);
+        $productOptionItem->setHidden($hidden);
         $productOptionItem->save();
         return $productOptionItem;
     }
 
 
-    public function update(StoreProduct $product,$name,$sort)
+    public function update(StoreProduct $product,$name,$sort, $hidden = false)
     {
         $pID = $product->getProductID();
         $this->setProductID($pID);
         $this->setName($name);
         $this->setSort($sort);
+        $this->setHidden($hidden);
         $this->save();
         return $this;
     }

--- a/src/VividStore/Product/ProductVariation/ProductVariation.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariation.php
@@ -4,6 +4,7 @@ namespace Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation;
 use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariationOptionItem as StoreProductVariationOptionItem;
 use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
+use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
 use Doctrine\Common\Collections\ArrayCollection;
 use Database;
 
@@ -89,6 +90,19 @@ class ProductVariation
         return $this->options;
     }
 
+    public function getOptionItemIDs() {
+        $options = $this->getOptions();
+
+        $optionids = array();
+
+        foreach($options as $opt) {
+            $optionids[] = $opt->getOption()->getID();
+        }
+
+        sort($optionids);
+        return $optionids;
+    }
+
 
     /**
      * @return mixed
@@ -137,6 +151,11 @@ class ProductVariation
     public function getVariationPrice()
     {
         return $this->pvPrice;
+    }
+
+    public function getFormattedVariationPrice()
+    {
+        return StorePrice::format($this->pvPrice);
     }
 
     /**
@@ -349,7 +368,7 @@ class ProductVariation
 
     public function save()
     {
-        $em = Database::get()->getEntityManager();
+        $em = Database::connection()->getEntityManager();
         $em->persist($this);
         $em->flush();
     }

--- a/src/VividStore/Product/ProductVariation/ProductVariation.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariation.php
@@ -7,6 +7,7 @@ use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOpt
 use \Concrete\Package\VividStore\Src\VividStore\Utilities\Price as StorePrice;
 use Doctrine\Common\Collections\ArrayCollection;
 use Database;
+use File;
 
 /**
  * @Entity
@@ -394,17 +395,17 @@ class ProductVariation
                     $variation = self::add(
                         $product->getProductID(),
                         array(
-                        'pvSKU' => $data['pvSKU'][$key],
-                        'pvPrice' => $data['pvPrice'][$key],
-                        'pvSalePrice'=>$data['pvSalePrice'][$key],
-                        'pvQty'=>$data['pvQty'][$key],
-                        'pvQtyUnlim'=>$data['pvQtyUnlim'][$key],
-                        'pvfID'=>$data['pvfID'][$key],
-                        'pvWeight'=>$data['pvWidth'][$key],
-                        'pvNumberItems'=>$data['pvNumberItems'][$key],
-                        'pvWidth'=>$data['pvWidth'][$key],
-                        'pvHeight'=>$data['pvHeight'][$key],
-                        'pvLength'=>$data['pvLength'][$key])
+                        'pvSKU' => '',
+                        'pvPrice' => '',
+                        'pvSalePrice'=>'',
+                        'pvQty'=>'',
+                        'pvQtyUnlim'=>'',
+                        'pvfID'=>'',
+                        'pvWeight'=>'',
+                        'pvNumberItems'=>'',
+                        'pvWidth'=>'',
+                        'pvHeight'=>'',
+                        'pvLength'=>'')
                     );
 
                     foreach($optioncombo as $optionvalue) {
@@ -418,6 +419,8 @@ class ProductVariation
                         }
                     }
                 } else {
+                    $key = $variation->getID();
+
                     $variation->setVariationSKU($data['pvSKU'][$key]);
                     $variation->setVariationPrice($data['pvPrice'][$key]);
                     $variation->setVariationSalePrice($data['pvSalePrice'][$key]);

--- a/src/VividStore/Product/ProductVariation/ProductVariation.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariation.php
@@ -369,7 +369,7 @@ class ProductVariation
                 foreach($pvIDstoDelete as $pvID) {
                     $variation = self::getByID($pvID);
                     if ($variation) {
-                        $variation->remove();
+                        $variation->delete();
                     }
                 }
             }
@@ -424,11 +424,26 @@ class ProductVariation
         return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation')->findBy(array('pID' => $product->getProductID()));
     }
 
-    public function remove()
+    public function delete()
     {
         $em = Database::connection()->getEntityManager();
         $em->remove($this);
         $em->flush();
+    }
+
+    public static function removeVariationsForProduct(StoreProduct $product, $excluding = array())
+    {
+        if (!is_array($excluding)) {
+            $excluding = array();
+        }
+
+        //clear out existing product option groups
+        $existingVariations = self::getVariationsForProduct($product);
+        foreach($existingVariations as $variation){
+            if (!in_array($variation->getID(), $excluding)) {
+                $variation->delete();
+            }
+        }
     }
 
 

--- a/src/VividStore/Product/ProductVariation/ProductVariation.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariation.php
@@ -1,0 +1,365 @@
+<?php
+namespace Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation;
+
+use \Concrete\Package\VividStore\Src\VividStore\Product\Product as StoreProduct;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariationOptionItem as StoreProductVariationOptionItem;
+use \Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem as StoreProductOptionItem;
+use Doctrine\Common\Collections\ArrayCollection;
+use Database;
+
+/**
+ * @Entity
+ * @Table(name="VividStoreProductVariations")
+ */
+class ProductVariation
+{
+
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    protected $pvID;
+
+    /**
+     * @Column(type="integer")
+     */
+    protected $pID;
+
+    /**
+     * @Column(type="decimal", precision=10, scale=2, nullable=true)
+     */
+    protected $pvPrice;
+
+    /**
+     * @Column(type="string",nullable=true)
+     */
+    protected $pvSKU;
+
+    /**
+    * @Column(type="decimal", precision=10, scale=2, nullable=true)
+    */
+    protected $pvSalePrice;
+
+    /**
+     * @Column(type="integer", nullable=true)
+     */
+    protected $pvQty;
+
+    /**
+     * @Column(type="boolean",nullable=true)
+     */
+    protected $pvQtyUnlim;
+
+    /**
+     * @Column(type="boolean", nullable=true)
+     */
+    protected $pvActive;
+
+    /**
+     * @Column(type="integer", nullable=true)
+     */
+    protected $pWidth;
+
+    /**
+     * @Column(type="integer", nullable=true)
+     */
+    protected $pHeight;
+
+    /**
+     * @Column(type="integer", nullable=true)
+     */
+    protected $pLength;
+
+    /**
+     * @Column(type="integer", nullable=true)
+     */
+    protected $pWeight;
+
+    /**
+     * @OneToMany(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariationOptionItem", mappedBy="variation"))
+     */
+    protected $options;
+
+
+    public function __construct() {
+        $this->options = new ArrayCollection();
+    }
+
+    public function getOptions() {
+        return $this->options;
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public function getID()
+    {
+        return $this->pvID;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getProductID()
+    {
+        return $this->pID;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationSKU()
+    {
+        return $this->pvSKU;
+    }
+
+    /**
+     * @param mixed $pvSKU
+     */
+    public function setVariationSKU($pvSKU)
+    {
+        $this->pvSKU = $pvSKU;
+    }
+
+
+    /**
+     * @param mixed $pID
+     */
+    public function setProductID($pID)
+    {
+        $this->pID = $pID;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationPrice()
+    {
+        return $this->pvPrice;
+    }
+
+    /**
+     * @param mixed $pvPrice
+     */
+    public function setVariationPrice($pvPrice)
+    {
+        $this->pvPrice = $pvPrice;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationSalePrice()
+    {
+        return $this->pvSalePrice;
+    }
+
+    /**
+     * @param mixed $pvSalePrice
+     */
+    public function setVariationSalePrice($pvSalePrice)
+    {
+        $this->pvSalePrice = $pvSalePrice;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationQty()
+    {
+        return $this->pvQty;
+    }
+
+    /**
+     * @param mixed $pvQty
+     */
+    public function setVariationQty($pvQty)
+    {
+        $this->pvQty = $pvQty;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationQtyUnlim()
+    {
+        return $this->pvQtyUnlim;
+    }
+
+    /**
+     * @param mixed $pvQtyUnlim
+     */
+    public function setVariationQtyUnlim($pvQtyUnlim)
+    {
+        $this->pvQtyUnlim = $pvQtyUnlim;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationActive()
+    {
+        return $this->pvActive;
+    }
+
+    /**
+     * @param mixed $pvActive
+     */
+    public function setVariationActive($pvActive)
+    {
+        $this->pvActive = $pvActive;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationWidth()
+    {
+        return $this->pWidth;
+    }
+
+    /**
+     * @param mixed $pWidth
+     */
+    public function setVariationWidth($pWidth)
+    {
+        $this->pWidth = $pWidth;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationHeight()
+    {
+        return $this->pHeight;
+    }
+
+    /**
+     * @param mixed $pHeight
+     */
+    public function setVariationHeight($pHeight)
+    {
+        $this->pHeight = $pHeight;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationLength()
+    {
+        return $this->pLength;
+    }
+
+    /**
+     * @param mixed $pLength
+     */
+    public function setVariationLength($pLength)
+    {
+        $this->pLength = $pLength;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getVariationWeight()
+    {
+        return $this->pWeight;
+    }
+
+    /**
+     * @param mixed $pWeight
+     */
+    public function setVariationWeight($pWeight)
+    {
+        $this->pWeight = $pWeight;
+    }
+
+    public function isUnlimited() {
+        return $this->getVariationQtyUnlim();
+    }
+
+    public static function addVariations(array $data, StoreProduct $product) {
+        foreach($data['option_combo'] as $key=>$optioncombo) {
+            $optionvalues = explode('_', $optioncombo);
+
+            $variation = self::getByOptionItemIDs($optionvalues);
+
+            if (!$variation) {
+                $variation = self::add(
+                    $product->getProductID(),
+                    $data['pvSKU'][$key],
+                    $data['pvPrice'][$key],
+                    $data['pvQty'][$key],
+                    $data['pvQtyUnlim'][$key]
+                );
+
+                foreach($optionvalues as $optionvalue) {
+                    $option = StoreProductOptionItem::getByID($optionvalue);
+
+                    if ($option) {
+                        $variationoption = new StoreProductVariationOptionItem();
+                        $variationoption->setOption($option);
+                        $variationoption->setVariation($variation);
+                        $variationoption->save();
+                    }
+                }
+            } else {
+                $variation->setVariationSKU($data['pvSKU'][$key]);
+                $variation->setVariationPrice($data['pvPrice'][$key]);
+                $variation->setVariationQty($data['pvQty'][$key]);
+                $variation->setVariationQtyUnlim($data['pvQtyUnlim'][$key]);
+                $variation->save();
+
+            }
+        }
+    }
+
+    public static function getByID($pvID) {
+        $db = Database::connection();
+        $em = $db->getEntityManager();
+        return $em->find('Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation', $pvID);
+    }
+
+    public static function add($productID, $sku, $price, $qty, $qtyUnlim)
+    {
+        $variation = new self();
+        $variation->setProductID($productID);
+        $variation->setVariationSKU($sku);
+        $variation->setVariationPrice($price);
+        $variation->setVariationQty($qty);
+        $variation->setVariationQtyUnlim($qtyUnlim);
+        $variation->save();
+        return $variation;
+    }
+
+    public static function getByOptionItemIDs(array $optionids) {
+        $db = \Database::connection();
+
+        if (is_array($optionids) && !empty($optionids)) {
+            $options = implode(',', $optionids);
+            $pvID = $db->fetchColumn("SELECT pvID FROM VividStoreProductVariationOptionItems WHERE poiID in ($options)
+                                 group by pvID having count(*) = ?", array(count($optionids)));
+
+            return self::getByID($pvID);
+        }
+
+        return false;
+    }
+
+    public function save()
+    {
+        $em = Database::get()->getEntityManager();
+        $em->persist($this);
+        $em->flush();
+    }
+
+    public static function getVariationsForProduct(StoreProduct $product)
+    {
+        $db = Database::connection();
+        $em = $db->getEntityManager();
+        return $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation')->findBy(array('pID' => $product->getProductID()));
+    }
+
+
+}

--- a/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
@@ -1,0 +1,58 @@
+<?php
+namespace Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation;
+
+use Database;
+
+/**
+ * @Entity
+ * @Table(name="VividStoreProductVariationOptionItems")
+ */
+class ProductVariationOptionItem
+{
+
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    protected $pvoiID;
+
+    /**
+     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation", inversedBy="options")*
+     * @JoinColumn(name="pvID", referencedColumnName="pvID")
+     */
+    protected $variation;
+
+    /**
+     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductOption\ProductOptionItem",cascade={"persist"})
+     * @JoinColumn(name="poiID", referencedColumnName="poiID", onDelete="CASCADE")
+     */
+    protected $option;
+
+    public function setVariation($variation)
+    {
+        $this->variation = $variation;
+    }
+
+    public function getVariation()
+    {
+        return $this->variation;
+    }
+
+    public function setOption($option)
+    {
+        $this->option = $option;
+    }
+
+    public function getOption()
+    {
+        return $this->option;
+    }
+
+    public function save()
+    {
+        $em = Database::get()->getEntityManager();
+        $em->persist($this);
+        $em->flush();
+    }
+
+}

--- a/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
@@ -17,7 +17,7 @@ class ProductVariationOptionItem
     protected $pvoiID;
 
     /**
-     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation", inversedBy="options", cascade={"persist"})*
+     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation", inversedBy="options", cascade={"persist"})
      * @JoinColumn(name="pvID", referencedColumnName="pvID", onDelete="CASCADE")
      */
     protected $variation;

--- a/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
@@ -28,6 +28,11 @@ class ProductVariationOptionItem
      */
     protected $option;
 
+
+    public function getID() {
+        return $this->pvoiID;
+    }
+
     public function setVariation($variation)
     {
         $this->variation = $variation;

--- a/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
+++ b/src/VividStore/Product/ProductVariation/ProductVariationOptionItem.php
@@ -17,8 +17,8 @@ class ProductVariationOptionItem
     protected $pvoiID;
 
     /**
-     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation", inversedBy="options")*
-     * @JoinColumn(name="pvID", referencedColumnName="pvID")
+     * @ManyToOne(targetEntity="Concrete\Package\VividStore\Src\VividStore\Product\ProductVariation\ProductVariation", inversedBy="options", cascade={"persist"})*
+     * @JoinColumn(name="pvID", referencedColumnName="pvID", onDelete="CASCADE")
      */
     protected $variation;
 

--- a/src/VividStore/Report/ProductReport.php
+++ b/src/VividStore/Report/ProductReport.php
@@ -37,23 +37,25 @@ class ProductReport extends AbstractItemList
     {
         $products = array();
         foreach($this->orderItems as $oi){
-            if(array_key_exists($oi->getProductID(),$products)){
-                $products[$oi->getProductID()]['pricePaid'] = intval($products[$oi->getProductID()]['pricePaid']) + intval($oi->getPricePaid());
-                $products[$oi->getProductID()]['quantity'] = intval($products[$oi->getProductID()]['quantity']) + intval($oi->getQty());
-            } else {
-                //first figure out what the current product name is.
-                //if the product no longer exist, the OI name is fine.
-                $product = StoreProduct::getByID($oi->getProductID());
-                if(is_object($product)){
-                    $name = $product->getProductName();
-                } else { $name = $oi->getProductName(); }
-                $products[$oi->getProductID()] = array(
-                    'name' => $name,
-                    'pID' => $oi->getProductID(),
-                    'pricePaid' => intval($oi->getPricePaid()) * intval($oi->getQty()),
-                    'quantity' => intval($oi->getQty())
-                );
-            }
+                if (array_key_exists($oi->getProductID(), $products)) {
+                    $products[$oi->getProductID()]['pricePaid'] = intval($products[$oi->getProductID()]['pricePaid']) + intval($oi->getPricePaid());
+                    $products[$oi->getProductID()]['quantity'] = intval($products[$oi->getProductID()]['quantity']) + intval($oi->getQty());
+                } else {
+                    //first figure out what the current product name is.
+                    //if the product no longer exist, the OI name is fine.
+                    $product = StoreProduct::getByID($oi->getProductID());
+                    if (is_object($product)) {
+                        $name = $product->getProductName();
+                    } else {
+                        $name = $oi->getProductName();
+                    }
+                    $products[$oi->getProductID()] = array(
+                        'name' => $name,
+                        'pID' => $oi->getProductID(),
+                        'pricePaid' => intval($oi->getPricePaid()) * intval($oi->getQty()),
+                        'quantity' => intval($oi->getQty())
+                    );
+                }
         }
         $this->products = $products;
         

--- a/src/VividStore/Utilities/Calculator.php
+++ b/src/VividStore/Utilities/Calculator.php
@@ -19,6 +19,10 @@ class Calculator
                 $pID = $cartItem['product']['pID'];
                 $qty = $cartItem['product']['qty'];
                 $product = StoreProduct::getByID($pID);
+
+                if ($cartItem['product']['variation']) {
+                    $product->setVariation($cartItem['product']['variation']);
+                }
                 if(is_object($product)){
                     $productSubTotal = $product->getActivePrice() * $qty;
                     $subtotal = $subtotal + $productSubTotal;


### PR DESCRIPTION
This adds product 'variations' - which are combinations of product options with specific prices, stock levels, product image (primary for now) and shipping values.

Other options/bugs with options have been tidied along the way.  The cart in particular has some re-worked logic, with it trying to always ensure it only contains valid product configurations.

Also starting to migrate away from <?= to use <?php echo, as that's preferred in the PRB.

![screen shot 2016-01-25 at 4 26 59 pm](https://cloud.githubusercontent.com/assets/1079600/12543569/907f7ea0-c380-11e5-973d-29e44bc3afff.png)

From a high level point of view, there is now a ProductVariation object, which tracks the specific details for a combo of options. Product objects in the system get injected with a ProductVariation object, which it then refers to when returning values.

The original way of having product options that aren't tracked should continue to work as expected.
