### PR TITLE
Make order filters translatable, fix error with filtering

### DIFF
--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -241,7 +241,7 @@ use \Concrete\Package\VividStore\Src\Attribute\Key\StoreOrderKey as StoreOrderKe
                 <ul id="group-filters" class="nav nav-pills">
                     <li><a href="<?php echo View::url('/dashboard/store/orders/')?>"><?=t('All Statuses')?></a></li>
                     <?php foreach($statuses as $status){ ?>
-                        <li><a href="<?php echo View::url('/dashboard/store/orders/', $status->getHandle())?>"><?=$status->getReadableHandle();?></a></li>
+                        <li><a href="<?php echo View::url('/dashboard/store/orders/', $status->getHandle())?>"><?=$status->getName();?></a></li>
                     <?php } ?>
                 </ul>
             <?php } ?>


### PR DESCRIPTION
This fixes the following issues

<img width="1343" alt="capture d ecran 2016-01-25 a 23 09 04" src="https://cloud.githubusercontent.com/assets/1079600/12569019/e99f19e2-c41a-11e5-8eac-f5b29a590037.png">
Labels not translated here:
<img width="741" alt="capture d ecran 2016-01-25 a 23 09 19" src="https://cloud.githubusercontent.com/assets/1079600/12569020/eb557452-c41a-11e5-850d-3373400a8f9b.png">
<img width="1053" alt="capture d ecran 2016-01-25 a 23 09 28" src="https://cloud.githubusercontent.com/assets/1079600/12569021/ed54f890-c41a-11e5-8550-ee50b0dbbe59.png">
