### PR TITLE
PHP7 Compatibility

### DIFF
--- a/src/Attribute/Key/StoreOrderKey.php
+++ b/src/Attribute/Key/StoreOrderKey.php
@@ -22,7 +22,7 @@ class StoreOrderKey extends Key {
         return $avl;
     }
     
-    public function load($akID) {
+    public function load($akID, $loadBy = 'akID') {
         parent::load($akID);
         $db = Database::get();
         $row = $db->GetRow("select * from VividStoreOrderAttributeKeys where akID = ?", array($akID));

--- a/src/Attribute/Key/StoreProductKey.php
+++ b/src/Attribute/Key/StoreProductKey.php
@@ -22,7 +22,7 @@ class StoreProductKey extends Key {
         return $avl;
     }
     
-    public function load($akID) {
+    public function load($akID, $loadBy = 'akID') {
         parent::load($akID);
         $db = Database::get();
         $row = $db->GetRow("select * from VividStoreProductAttributeKeys where akID = ?", array($akID));


### PR DESCRIPTION
fix for:
Declaration of Concrete\Package\VividStore\Block\VividProductList\Controller::registerViewAssets() should be compatible with Concrete\Core\Block\BlockController::registerViewAssets($outputContent = '')
