### PR TITLE
Add ounces (oz.) as shipping weight unit

### DIFF
--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -344,6 +344,7 @@ class products extends DashboardPageController
     {
         $grouplist = StoreGroupList::getGroupList();
         $this->set("grouplist", $grouplist);
+        $this->getAssets();
         $this->requireAsset('css', 'vividStoreDashboard');
         $this->requireAsset('javascript', 'vividStoreFunctions');
     }

--- a/js/vividStoreFunctions.js
+++ b/js/vividStoreFunctions.js
@@ -76,12 +76,14 @@ StoreDashboard.ProductGroup = {
         });
     },
     edit: function(groupID){
-        $("li['data-group-id="+groupID+"']").find(".btn-edit-group-name, .group-name").hide();
-        $("li['data-group-id="+groupID+"']").find(".edit-group-name, .btn-cancel-edit, .btn-save-group-name").attr("style","display: inline-block !important");
+        console.log('groupID: ' + groupID);
+        console.log('li[data-group-id="' + groupID + ']"')
+        $("li[data-group-id='"+groupID+"']").find('.btn-edit-group-name, .group-name').hide();
+        $("li[data-group-id='"+groupID+"']").find('.edit-group-name, .btn-cancel-edit, .btn-save-group-name').attr('style','display: inline-block !important');
     },
     cancel: function(groupID){
-        $("li['data-group-id="+groupID+"']").find(".btn-edit-group-name, .group-name").show();
-        $("li['data-group-id="+groupID+"']").find(".edit-group-name, .btn-cancel-edit, .btn-save-group-name").attr("style","display: none");
+        $("li[data-group-id='"+groupID+"']").find('.btn-edit-group-name, .group-name').show();
+        $("li[data-group-id='"+groupID+"']").find('.edit-group-name, .btn-cancel-edit, .btn-save-group-name').attr('style','display: none');
     }
 }
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -59,7 +59,7 @@
                             <div class="form-group">
                                 <?php echo $form->label('weightUnit', t('Units for Weight'));?>
                                 <?php // do not add other units to this list. these are specific to making calculated shipping work ?>
-                                <?php echo $form->select('weightUnit', array('lb'=>t('lb'), 'kg'=>t('kg'), 'g'=>t('g')), Config::get('vividstore.weightUnit'));?>
+                                <?php echo $form->select('weightUnit', array('lb'=>t('lb'), 'kg'=>t('kg'), 'g'=>t('g'), 'oz'=>t('oz')), Config::get('vividstore.weightUnit'));?>
                             </div>
                         </div> 
                         <div class="col-xs-6">

--- a/src/VividStore/Product/ProductGroup.php
+++ b/src/VividStore/Product/ProductGroup.php
@@ -59,7 +59,11 @@ class ProductGroup
         $groups = $em->getRepository('Concrete\Package\VividStore\Src\VividStore\Product\ProductGroup')->findBy(array('pID' => $product->getProductID()));
         foreach ($groups as $key => $value) {
             $group = new StoreGroup\Group;
-            $groups[$key]->gName = $group->getByID($groups[$key]->gID)->getGroupName();
+            if ($group->getByID($groups[$key]->gID)) {
+                $groups[$key]->gName = $group->getByID($groups[$key]->gID)->getGroupName();
+            } else {
+                $groups[$key]->gName = 'undefined';
+            }
         }
         return $groups;
     }

--- a/src/VividStore/Product/ProductList.php
+++ b/src/VividStore/Product/ProductList.php
@@ -161,7 +161,9 @@ class ProductList extends AttributedItemList
     protected function createPaginationObject()
     {
         $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
-            $query->select('count(distinct p.pID)')->setMaxResults(1);
+            $values = $query->execute()->fetchAll();
+            $count = count($values);
+            $query->resetQueryParts(array('groupBy', 'orderBy', 'having', 'join', 'where', 'from'))->from('DUAL')->select($count . ' c ');
         });
         $pagination = new Pagination($this, $adapter);
         return $pagination;
@@ -170,6 +172,8 @@ class ProductList extends AttributedItemList
     public function getTotalResults()
     {
         $query = $this->deliverQueryObject();
-        return $query->select('count(distinct p.pID)')->setMaxResults(1)->execute()->fetchColumn();
+        $values = $query->execute()->fetchAll();
+        $count = count($values);
+        return $query->resetQueryParts(array('groupBy', 'orderBy', 'having', 'join', 'where', 'from'))->from('DUAL')->select($count)->setMaxResults(1)->execute()->fetchColumn();
     }
 }

--- a/src/VividStore/Utilities/Calculator.php
+++ b/src/VividStore/Utilities/Calculator.php
@@ -143,6 +143,9 @@ class Calculator
             case "g":
                 $grams = $weight;
                 break;
+            case "oz":
+                $grams = $weight / 0.0352736;
+                break;
         }
         return $grams;
     }
@@ -159,6 +162,9 @@ class Calculator
                 break;
             case "g":
                 $weight = $grams;
+                break;
+            case "oz":
+                $grams = $weight * 0.0352736;
                 break;
         }
         return $weight;

--- a/src/VividStore/Utilities/Calculator.php
+++ b/src/VividStore/Utilities/Calculator.php
@@ -164,7 +164,7 @@ class Calculator
                 $weight = $grams;
                 break;
             case "oz":
-                $grams = $weight * 0.0352736;
+                $weight = $grams * 0.0352736;
                 break;
         }
         return $weight;


### PR DESCRIPTION
This change simply adds "oz" as an additional shipping weight unit and adds ounce conversion to the Calculator utility.

If most of a store's product weights are measured in U.S. ounces, it is much more desirable for the store admins to have ounces as a shipping weight option. Otherwise store admins have to manually convert all product weights to the existing "lb", "kg", or "g" options.
